### PR TITLE
feat: Add KServe Integration notebook

### DIFF
--- a/tests/notebooks/kserve-integration.ipynb
+++ b/tests/notebooks/kserve-integration.ipynb
@@ -1,0 +1,369 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2b1c430f-1b3c-4c18-b5b3-0b3757f01259",
+   "metadata": {},
+   "source": [
+    "# Test KServe Integration\n",
+    "\n",
+    "This example notebook is loosely based on [this](https://github.com/kubeflow/examples/blob/master/kserve/sdk/first_isvc_kserve.ipynb) upstream example.\n",
+    "\n",
+    "- create Inference Service\n",
+    "- perform inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26ac0a3d-10ee-4f92-a9e0-e1b5c550bd8b",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9fbb8bc8-0eb0-4853-bef6-e2098eb2829c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install kserve kubernetes requests tenacity -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "306c9dc8-2ee7-4d2d-bbf8-38f4fadd3c73",
+   "metadata": {},
+   "source": [
+    "### Import required packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "715c03bb-ef5a-4468-a370-a106f44061bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "\n",
+    "from kserve import (\n",
+    "    constants,\n",
+    "    KServeClient,\n",
+    "    V1beta1InferenceService,\n",
+    "    V1beta1InferenceServiceSpec,\n",
+    "    V1beta1PredictorSpec,\n",
+    "    V1beta1SKLearnSpec,\n",
+    ")\n",
+    "from kubernetes.client import V1ObjectMeta\n",
+    "from tenacity import retry, stop_after_attempt, wait_exponential"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d29d9ed-dd6e-474c-93f9-dceaa25109d4",
+   "metadata": {},
+   "source": [
+    "## Define Inference Service"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2e10aac9-72ed-4ff6-a089-60b821d06911",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ISVC_NAME = \"sklearn-iris\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c4f6a4fb-a21c-49cc-8b4f-100fff22b0d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "isvc = V1beta1InferenceService(\n",
+    "    api_version=constants.KSERVE_V1BETA1,\n",
+    "    kind=constants.KSERVE_KIND,\n",
+    "    metadata=V1ObjectMeta(\n",
+    "        name=ISVC_NAME,\n",
+    "        annotations={\"sidecar.istio.io/inject\": \"false\"},\n",
+    "    ),\n",
+    "    spec=V1beta1InferenceServiceSpec(\n",
+    "        predictor=V1beta1PredictorSpec(\n",
+    "            sklearn=V1beta1SKLearnSpec(\n",
+    "                storage_uri=\"gs://kfserving-examples/models/sklearn/1.0/model\"\n",
+    "            )\n",
+    "        )\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6348b4c0-42d0-4dc1-bdb4-8f686bcdbbb7",
+   "metadata": {},
+   "source": [
+    "## Create Inference Service"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3ed57ac-2170-4b60-949d-898cb7787e52",
+   "metadata": {},
+   "source": [
+    "### Initialise KServe Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "35dc21f1-d3c4-4693-867b-2ebfd141c161",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = KServeClient()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f12f22a-5aca-40bf-9930-e68c0fc3ee85",
+   "metadata": {},
+   "source": [
+    "### Submit Inference Service"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f02a6871-da47-4f55-b7d3-80da300488f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'apiVersion': 'serving.kserve.io/v1beta1',\n",
+       " 'kind': 'InferenceService',\n",
+       " 'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},\n",
+       "  'creationTimestamp': '2023-08-07T09:50:16Z',\n",
+       "  'generation': 1,\n",
+       "  'managedFields': [{'apiVersion': 'serving.kserve.io/v1beta1',\n",
+       "    'fieldsType': 'FieldsV1',\n",
+       "    'fieldsV1': {'f:metadata': {'f:annotations': {'.': {},\n",
+       "       'f:sidecar.istio.io/inject': {}}},\n",
+       "     'f:spec': {'.': {},\n",
+       "      'f:predictor': {'.': {},\n",
+       "       'f:sklearn': {'.': {}, 'f:name': {}, 'f:storageUri': {}}}}},\n",
+       "    'manager': 'OpenAPI-Generator',\n",
+       "    'operation': 'Update',\n",
+       "    'time': '2023-08-07T09:50:14Z'}],\n",
+       "  'name': 'sklearn-iris',\n",
+       "  'namespace': 'test',\n",
+       "  'resourceVersion': '56838',\n",
+       "  'uid': 'ece28eaa-802a-45ce-a71d-22af323a3528'},\n",
+       " 'spec': {'predictor': {'model': {'modelFormat': {'name': 'sklearn'},\n",
+       "    'name': '',\n",
+       "    'resources': {},\n",
+       "    'storageUri': 'gs://kfserving-examples/models/sklearn/1.0/model'}}}}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client.create(isvc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e8cb648e-bf9d-455e-a40e-022c35772aa3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@retry(\n",
+    "    wait=wait_exponential(multiplier=2, min=1, max=10),\n",
+    "    stop=stop_after_attempt(30),\n",
+    "    reraise=True,\n",
+    ")\n",
+    "def assert_isvc_created(client, isvc_name):\n",
+    "    \"\"\"Wait for the Inference Service to be created successfully.\"\"\"\n",
+    "    assert client.is_isvc_ready(ISVC_NAME), f\"Failed to create Inference Service {isvc_name}.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "50871dc2-9ef1-4458-813b-2d9dca03c6a1",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert_isvc_created(client, ISVC_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c03aeca-0828-4db1-9051-88eb25a26277",
+   "metadata": {},
+   "source": [
+    "## Perform Inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8522c4e9-07b7-4bff-9b49-3675ff19bacc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inference URL: http://sklearn-iris.test.svc.cluster.local/v1/models/sklearn-iris:predict\n"
+     ]
+    }
+   ],
+   "source": [
+    "isvc_resp = client.get(ISVC_NAME)\n",
+    "isvc_url = isvc_resp['status']['address']['url']\n",
+    "print(\"Inference URL:\", isvc_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2557d625-b08f-4086-9626-2c4cd8dabe66",
+   "metadata": {},
+   "source": [
+    "Hit the service for predictions using the above URL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4ef27af2-9ae0-4adf-9058-ecc5ac84ef24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"predictions\":[1,1]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "inference_input = {\n",
+    "  \"instances\": [\n",
+    "    [6.8,  2.8,  4.8,  1.4],\n",
+    "    [6.0,  3.4,  4.5,  1.6]\n",
+    "  ]\n",
+    "}\n",
+    "response = requests.post(isvc_url, json=inference_input)\n",
+    "print(response.text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "9559d383-8124-4201-b160-bd8cc7784d48",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "res = response.json()\n",
+    "# verify that the predictions are as expected\n",
+    "assert res.get(\"predictions\"), \"Failed to get predictions!\"\n",
+    "assert res[\"predictions\"] == [1, 1], \"Predictions different than expected!\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7c75c2c-0be2-4055-a09c-0a0da616a3b8",
+   "metadata": {},
+   "source": [
+    "## Delete Inference Service"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a8d14051-decb-4c14-bc16-7ea04c3dd371",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.delete(ISVC_NAME);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "95ae1ec2-7275-4e02-a193-3a19f7501637",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "@retry(\n",
+    "    wait=wait_exponential(multiplier=2, min=1, max=10),\n",
+    "    stop=stop_after_attempt(30),\n",
+    "    reraise=True,\n",
+    ")\n",
+    "def assert_isvc_deleted(client, isvc_name):\n",
+    "    \"\"\"Wait for the Inference Service to be deleted.\"\"\"\n",
+    "    try:\n",
+    "        # try fetching the ISVC to verify it was deleted successfully\n",
+    "        isvc = client.get(isvc_name)\n",
+    "        assert not isvc, f\"Failed to delete Inference Service {isvc_name}!\"\n",
+    "    except RuntimeError as err:\n",
+    "        assert \"Not Found\" in str(err), f\"Caught unexpected exception: {err}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b0961b27-6c5e-43ea-bbcc-241c925a7839",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert_isvc_deleted(client, ISVC_NAME)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Introduce notebook to test KServe Integration:
* create an Inference Service
* perform inference

**This only works with `Serverless` deployment mode at the moment**, see the following issue for more:
* https://github.com/canonical/kserve-operators/issues/148

### Running with `Serverless`

In order to switch to `Serverless` (see [here](https://github.com/canonical/kserve-operators#deploy-in-serverless-mode) for more):
* update the `kserve-controller` config:

   ```bash
   juju config kserve-controller deployment-mode="serverless"
   ```
* relate `kserve-controller` to `knative-serving`:

   ```bash
   juju relate kserve-controller:local-gateway knative-serving:local-gateway
   ```

#### Patch ConfigMap

Even with KServe deployed in `Serverless` mode, we still have the bug described in the following issue:
* https://github.com/canonical/kserve-operators/issues/150

Until the above is resolved, we have to manually patch the `inferenceservice-config` ConfigMap in order to be able to hit any created InferenceServices:

```bash
kubectl -n kubeflow edit cm inferenceservice-config
```
Apply the following change:

```diff
-      "localGateway" : "kubeflow/knative-local-gateway",
+      "localGateway" : "knative-serving/knative-local-gateway",
```
