### PR TITLE
feat: Add E2E Wine test notebook

### DIFF
--- a/tests/notebooks/e2e-wine/.gitignore
+++ b/tests/notebooks/e2e-wine/.gitignore
@@ -1,0 +1,4 @@
+*.csv
+*.yaml
+*.parquet
+

--- a/tests/notebooks/e2e-wine/e2e-wine-kfp-mlflow-seldon.ipynb
+++ b/tests/notebooks/e2e-wine/e2e-wine-kfp-mlflow-seldon.ipynb
@@ -1,0 +1,913 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e89bf654",
+   "metadata": {},
+   "source": [
+    "# E2E scenario for Wine dataset on KFP\n",
+    "\n",
+    "Steps:\n",
+    "- download dataset\n",
+    "- clean/preprocess data\n",
+    "- perform training / hyper-parameter tuning with results in MLFlow + MinIO\n",
+    "- serve with Seldon\n",
+    "- perform inference\n",
+    "\n",
+    "Artifacts:\n",
+    "- raw data, preprocessed\n",
+    "- model per experiment\n",
+    "- experiment metadata and results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "305893d4-1f6b-4224-a932-94092616afd9",
+   "metadata": {},
+   "source": [
+    "## Tested with\n",
+    "\n",
+    "This notebook has been tested with the following core component versions:\n",
+    "\n",
+    "|                              |     **Charm**     | **Client** |                            **Image**                           |\n",
+    "|:----------------------------:|:-----------------:|:----------:|:--------------------------------------------------------------:|\n",
+    "| **Kubeflow Pipelines (KFP)** |      2.0/edge     |   1.8.22   |           gcr.io/ml-pipeline/api-server:2.0.0-alpha.7          |\n",
+    "|          **MLFlow**          | latest/edge (2.1) |    2.1.1   |             docker.io/ubuntu/mlflow:2.1.1_1.0-22.04            |\n",
+    "|           **MinIO**          |    ckf-1.7/edge   |    6.0.2   |            minio/minio:RELEASE.2021-09-03T03-56-13Z            |\n",
+    "|          **Seldon**          |     1.15/edge     |     N/A    | docker.io/charmedkubeflow/seldon-core-operator:v1.15.0_22.04_1 |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ce43dce-51b6-4d90-86d2-be1dfafff9a8",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e34b594",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!pip install boto3 kfp==1.8.22 minio mlflow==2.1.1 numpy pyarrow requests \"scikit-learn<1.2\" tenacity -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86d0a0b5-4e2a-4fca-96a8-8b3bc104bcf2",
+   "metadata": {},
+   "source": [
+    "### Import required packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0847708",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from urllib import request\n",
+    "\n",
+    "import kfp\n",
+    "import mlflow\n",
+    "import requests\n",
+    "\n",
+    "from kfp import dsl\n",
+    "from kfp.onprem import use_k8s_secret\n",
+    "from kubernetes import client as k8s_client, config as k8s_config\n",
+    "from kubernetes.client.exceptions import ApiException\n",
+    "from kubernetes.client.models import V1EnvVar\n",
+    "from minio import Minio\n",
+    "from minio.error import BucketAlreadyOwnedByYou\n",
+    "from sklearn.linear_model import ElasticNet\n",
+    "from tenacity import retry, stop_after_attempt, wait_exponential"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a79d42c8-2f1d-41d2-a3f7-3dd7271cd2f8",
+   "metadata": {},
+   "source": [
+    "### Initialise KFP Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54f90796-d2e0-400e-baf7-f0d6571b07c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = kfp.Client()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "974de7b5-7241-4ccb-9d3f-44c62eb82395",
+   "metadata": {},
+   "source": [
+    "### Create MinIO Bucket for MLFlow\n",
+    "\n",
+    "Create a MinIO bucket for MLFlow if it doesn't already exist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4c299ac-8435-42f2-8cec-e3d03843195e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MINIO_BUCKET = \"mlflow\"\n",
+    "MINIO_HOST = os.getenv(\"MINIO_ENDPOINT_URL\").split(\"http://\")[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6b7a59a-2264-481c-a45f-d9fe67419ae8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# initialise MinIO client\n",
+    "mc = Minio(\n",
+    "    endpoint=MINIO_HOST,\n",
+    "    access_key=os.environ[\"AWS_ACCESS_KEY_ID\"],\n",
+    "    secret_key=os.environ[\"AWS_SECRET_ACCESS_KEY\"],\n",
+    "    secure=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f86b38b9-f7df-4f21-9641-fbe15c952010",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    mc.make_bucket(MINIO_BUCKET)\n",
+    "except BucketAlreadyOwnedByYou:\n",
+    "    print(f\"Bucket {MINIO_BUCKET} already exists!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85e6967b",
+   "metadata": {},
+   "source": [
+    "## Download Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b5e4a40-8acc-45d0-9b13-86a2b5f27ce0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_URL = \"https://raw.githubusercontent.com/canonical/kubeflow-examples/main/e2e-wine-kfp-mlflow/winequality-red.csv\"\n",
+    "DATA_FILE = \"winequality-red.csv\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6442ab5f-2c87-49e4-88d3-4a88b3ec1eb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# local development\n",
+    "request.urlretrieve(DATA_URL, DATA_FILE)\n",
+    "\n",
+    "print(f\"File '{DATA_FILE}' downloaded successfully.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebc1a73b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# workflow component\n",
+    "web_downloader_op = kfp.components.load_component_from_url(\n",
+    "    \"https://raw.githubusercontent.com/kubeflow/pipelines/1.8.22/components/contrib/web/Download/component.yaml\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eee78a75",
+   "metadata": {},
+   "source": [
+    "## Preprocess Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1053d49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def preprocess(\n",
+    "    file_path: kfp.components.InputPath(\"CSV\"),\n",
+    "    output_file: kfp.components.OutputPath(\"parquet\")\n",
+    "):\n",
+    "    import pandas as pd\n",
+    "    df = pd.read_csv(file_path, header=0, sep=\";\")\n",
+    "    df.columns = [c.lower().replace(\" \", \"_\") for c in df.columns]\n",
+    "    df.to_parquet(output_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ae06565",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# local development\n",
+    "OUTPUT_PARQUET_FILE = \"preprocessed.parquet\"\n",
+    "preprocess(DATA_FILE, OUTPUT_PARQUET_FILE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ffd57c1-5eed-4031-a9d8-e9acff328af8",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert os.path.exists(OUTPUT_PARQUET_FILE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d06a68e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# workflow component\n",
+    "preprocess_op = kfp.components.create_component_from_func(\n",
+    "    func=preprocess,\n",
+    "    output_component_file=\"preprocess-component.yaml\",\n",
+    "    base_image=\"python:3.8.10\",\n",
+    "    packages_to_install=[\"pandas\", \"pyarrow\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e2b5fed",
+   "metadata": {},
+   "source": [
+    "## Train Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c43576b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def training(file_path: kfp.components.InputPath(\"parquet\")) -> str:\n",
+    "    import os\n",
+    "    import mlflow\n",
+    "    import pandas as pd\n",
+    "\n",
+    "    from sklearn.linear_model import ElasticNet\n",
+    "    from sklearn.metrics import classification_report\n",
+    "    from sklearn.model_selection import train_test_split\n",
+    "    \n",
+    "    df = pd.read_parquet(file_path)\n",
+    "    \n",
+    "    target_column=\"quality\"\n",
+    "    train_x, test_x, train_y, test_y = train_test_split(\n",
+    "        df.drop(columns=[target_column]),\n",
+    "        df[target_column], test_size=.25,\n",
+    "        random_state=42, stratify=df[target_column]\n",
+    "    )\n",
+    "\n",
+    "    mlflow.sklearn.autolog()\n",
+    "    with mlflow.start_run(run_name=\"elastic_net_models\") as run:\n",
+    "        mlflow.set_tag(\"author\", \"kf-testing\")\n",
+    "        lr = ElasticNet(alpha=0.5, l1_ratio=0.5, random_state=42)\n",
+    "        lr.fit(train_x, train_y)\n",
+    "        model_dir = \"model\"\n",
+    "        mlflow.sklearn.log_model(lr, model_dir, registered_model_name=\"wine-elasticnet\")\n",
+    "        return f\"{run.info.artifact_uri}/{model_dir}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "709a10b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# local development\n",
+    "training(OUTPUT_PARQUET_FILE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3a7378b-cf66-42ba-b212-aea73bd2e5c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run = mlflow.last_active_run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50fdc7d2-1e4d-4a15-8731-01057aee72b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@retry(\n",
+    "    wait=wait_exponential(multiplier=2, min=1, max=10),\n",
+    "    stop=stop_after_attempt(30),\n",
+    "    reraise=True,\n",
+    ")\n",
+    "def assert_mlflow_run_finished(client, run_id):\n",
+    "    \"\"\"Wait for the run to complete successfully.\"\"\"\n",
+    "    status = client.get_run(run_id).info.status\n",
+    "    assert status == \"FINISHED\", f\"MLFlow run in {status} state.\"\n",
+    "\n",
+    "\n",
+    "def assert_mlflow_model_exists(client, run_id):\n",
+    "    \"\"\"Assert Model exists.\"\"\"\n",
+    "    model = client.sklearn.load_model(f\"runs:/{run_id}/model\")\n",
+    "    assert isinstance(model, ElasticNet), f\"Model {model} is not of type ElasticNet!\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "836dd8a4-3caa-4438-9e1f-3d9e7307d668",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert run.data.tags.get(\"author\") == \"kf-testing\"\n",
+    "assert_mlflow_run_finished(mlflow, run.info.run_id)\n",
+    "assert_mlflow_model_exists(mlflow, run.info.run_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2606489-1dc6-47c1-adc0-d8e706cfbc8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# workflow component\n",
+    "training_op = kfp.components.create_component_from_func(\n",
+    "    func=training,\n",
+    "    output_component_file=\"train-component.yaml\",\n",
+    "    base_image=\"python:3.8.10\",\n",
+    "    packages_to_install=[\"boto3\", \"mlflow==2.1.1\", \"numpy\", \"pandas\", \"pyarrow\", \"scikit-learn<1.2\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c10c6991",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Deploy Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9599d635-f945-476f-a275-ec89eb5b080f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SELDON_DEPLOYMENT_NAME = \"kf-testing\"\n",
+    "SELDON_IMAGE = \"seldonio/mlflowserver:1.17.0\"\n",
+    "MODEL_NAME = \"wine-model\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86bdbfa6-fb71-4c7c-87e5-d2193bbd75c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def deploy(\n",
+    "    seldon_deployment_name: str = \"default_seldon_deployment_name\",\n",
+    "    seldon_image: str = \"default_seldon_image\",\n",
+    "    model_uri: str = \"default_model_uri\",\n",
+    "    model_name: str = \"default_model_name\",\n",
+    "):\n",
+    "    import yaml\n",
+    "\n",
+    "    from kubernetes import client, config\n",
+    "\n",
+    "    manifest = \"\"\"\n",
+    "apiVersion: machinelearning.seldon.io/v1\n",
+    "kind: SeldonDeployment\n",
+    "metadata:\n",
+    "  name: \"\"\" + seldon_deployment_name + \"\"\"\n",
+    "spec:\n",
+    "  name: wines\n",
+    "  predictors:\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - name: classifier\n",
+    "          image: \"\"\" + seldon_image + \"\"\"\n",
+    "          imagePullPolicy: Always\n",
+    "          livenessProbe:\n",
+    "            initialDelaySeconds: 80\n",
+    "            failureThreshold: 200\n",
+    "            periodSeconds: 5\n",
+    "            successThreshold: 1\n",
+    "            httpGet:\n",
+    "              path: /health/ping\n",
+    "              port: http\n",
+    "              scheme: HTTP\n",
+    "          readinessProbe:\n",
+    "            initialDelaySeconds: 80\n",
+    "            failureThreshold: 200\n",
+    "            periodSeconds: 5\n",
+    "            successThreshold: 1\n",
+    "            httpGet:\n",
+    "              path: /health/ping\n",
+    "              port: http\n",
+    "              scheme: HTTP\n",
+    "    graph:\n",
+    "      children: []\n",
+    "      implementation: MLFLOW_SERVER\n",
+    "      modelUri: \"\"\" + model_uri + \"\"\"\n",
+    "      envSecretRefName: mlflow-server-seldon-rclone-secret\n",
+    "      name: classifier\n",
+    "    name: \"\"\" + model_name + \"\"\"\n",
+    "    replicas: 1\n",
+    "    \"\"\"\n",
+    "\n",
+    "    with open(\"/var/run/secrets/kubernetes.io/serviceaccount/namespace\", \"r\") as f:\n",
+    "        namespace = f.read().strip()\n",
+    "\n",
+    "    config.load_incluster_config()\n",
+    "    api_instance = client.ApiClient()\n",
+    "    custom_api = client.CustomObjectsApi(api_instance)\n",
+    "\n",
+    "    try:\n",
+    "        api_response = custom_api.create_namespaced_custom_object(\n",
+    "            group=\"machinelearning.seldon.io\",\n",
+    "            version=\"v1\",\n",
+    "            plural=\"seldondeployments\",\n",
+    "            namespace=namespace,\n",
+    "            body=yaml.safe_load(manifest),\n",
+    "        )\n",
+    "        print(\"Custom Resource applied successfully.\")\n",
+    "        print(api_response)\n",
+    "    except client.rest.ApiException as e:\n",
+    "        print(f\"Failed to apply Custom Resource: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43fd4a17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# workflow component\n",
+    "deploy_op = kfp.components.create_component_from_func(\n",
+    "    func=deploy,\n",
+    "    output_component_file=\"deploy-component.yaml\",\n",
+    "    base_image=\"python:3.8.10\",\n",
+    "    packages_to_install=[\"kubernetes\", \"pyyaml\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce03a720",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Create Pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8dec0d0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@dsl.pipeline(\n",
+    "    name=\"e2e_wine_pipeline\",\n",
+    "    description=\"E2E Wine Pipeline with MLFlow and Seldon\",\n",
+    ")\n",
+    "def wine_pipeline(url, seldon_deployment_name, seldon_image, model_name):\n",
+    "    web_downloader_task = web_downloader_op(url=url)\n",
+    "    preprocess_task = preprocess_op(file=web_downloader_task.outputs[\"data\"])\n",
+    "    train_task = (\n",
+    "        training_op(file=preprocess_task.outputs[\"output\"])\n",
+    "        .add_env_variable(V1EnvVar(name=\"MLFLOW_TRACKING_URI\", value=os.getenv(\"MLFLOW_TRACKING_URI\")))\n",
+    "        .add_env_variable(V1EnvVar(name=\"MLFLOW_S3_ENDPOINT_URL\", value=os.getenv(\"MLFLOW_S3_ENDPOINT_URL\")))\n",
+    "        .add_env_variable(V1EnvVar(name=\"PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION\", value=\"python\"))\n",
+    "        .apply(\n",
+    "            use_k8s_secret(\n",
+    "                secret_name=\"mlflow-server-minio-artifact\",\n",
+    "                k8s_secret_key_to_env={\n",
+    "                    \"AWS_ACCESS_KEY_ID\": \"AWS_ACCESS_KEY_ID\",\n",
+    "                    \"AWS_SECRET_ACCESS_KEY\": \"AWS_SECRET_ACCESS_KEY\",\n",
+    "                },\n",
+    "            )\n",
+    "        )\n",
+    "    )\n",
+    "    deploy_task = deploy_op(\n",
+    "        seldon_deployment_name=seldon_deployment_name,\n",
+    "        seldon_image=seldon_image,\n",
+    "        model_uri=train_task.output,\n",
+    "        model_name=model_name,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7605db80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# local development\n",
+    "kfp.compiler.Compiler().compile(wine_pipeline, \"wine-pipeline.yaml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03bb3c27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run = client.create_run_from_pipeline_func(\n",
+    "    wine_pipeline,\n",
+    "    arguments={\n",
+    "        \"url\": DATA_URL,\n",
+    "        \"seldon_deployment_name\": SELDON_DEPLOYMENT_NAME,\n",
+    "        \"seldon_image\": SELDON_IMAGE,\n",
+    "        \"model_name\": MODEL_NAME,\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d844a863-e385-4318-95e5-dfa6c17c6c70",
+   "metadata": {},
+   "source": [
+    "## Monitor KFP Run\n",
+    "\n",
+    "Wait for the KFP run to be completed successfully."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75bbffd7-ef72-445b-b4bf-473264d53ee0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@retry(\n",
+    "    wait=wait_exponential(multiplier=2, min=1, max=10),\n",
+    "    stop=stop_after_attempt(30),\n",
+    "    reraise=True,\n",
+    ")\n",
+    "def assert_kfp_run_succeeded(client, run_id):\n",
+    "    \"\"\"Wait for the run to complete successfully.\"\"\"\n",
+    "    status = client.get_run(run_id).run.status\n",
+    "    assert status == \"Succeeded\", f\"KFP run in {status} state.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70f27dba-e334-4400-9a79-1d1b51fa30d5",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert_kfp_run_succeeded(client, run.run_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74d27471-56ea-425e-a0ee-6d34cdf13301",
+   "metadata": {},
+   "source": [
+    "## Perform Inference\n",
+    "\n",
+    "Wait for the SeldonDeployment to become available and hit it for predictions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4d89530-36ab-4d23-9b91-3cb36767d3ca",
+   "metadata": {},
+   "source": [
+    "### Setup K8s Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0f37c62-fc3d-4279-a698-6b3dca50f07b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"/var/run/secrets/kubernetes.io/serviceaccount/namespace\", \"r\") as f:\n",
+    "    NAMESPACE = f.read().strip()\n",
+    "\n",
+    "k8s_config.load_incluster_config()\n",
+    "api_instance = k8s_client.ApiClient()\n",
+    "custom_api = k8s_client.CustomObjectsApi(api_instance)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7ae4e12-10d7-4f2f-bf4f-abe7ae8baddf",
+   "metadata": {},
+   "source": [
+    "### Define K8s Helpers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "299ef526-4a6d-453e-9a47-500bbc2e1e2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_seldon_deployment(name, namespace):\n",
+    "    \"\"\"Get SeldonDeployment by name.\"\"\"\n",
+    "    return custom_api.get_namespaced_custom_object(\n",
+    "        group=\"machinelearning.seldon.io\",\n",
+    "        version=\"v1\",\n",
+    "        plural=\"seldondeployments\",\n",
+    "        namespace=namespace,\n",
+    "        name=name,\n",
+    "    )\n",
+    "\n",
+    "def delete_seldon_deployment(name, namespace):\n",
+    "    \"\"\"Delete SeldonDeployment by name.\"\"\"\n",
+    "    return custom_api.delete_namespaced_custom_object(\n",
+    "        group=\"machinelearning.seldon.io\",\n",
+    "        version=\"v1\",\n",
+    "        plural=\"seldondeployments\",\n",
+    "        namespace=namespace,\n",
+    "        name=name,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ccb1eccf-fb61-4045-a666-a6ab9b13bd1c",
+   "metadata": {},
+   "source": [
+    "### Wait for SeldonDeployment to Become Available"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbdfb881-503f-4875-8ad5-99bdcb154021",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@retry(\n",
+    "    wait=wait_exponential(multiplier=2, min=1, max=10),\n",
+    "    stop=stop_after_attempt(50),\n",
+    "    reraise=True,\n",
+    ")\n",
+    "def assert_seldon_deployment_available(seldon_deployment_name, namespace):\n",
+    "    \"\"\"Wait for the SeldonDeployment to become available.\"\"\"\n",
+    "    try:\n",
+    "        sd = get_seldon_deployment(seldon_deployment_name, namespace)\n",
+    "    except ApiException as err:\n",
+    "        assert err.status != 404, f\"SeldonDeployment {seldon_deployment_name} not found!\"\n",
+    "        raise\n",
+    "    status = sd.get(\"status\")\n",
+    "    assert status is not None, \"SeldonDeployment status not yet available!\"\n",
+    "    assert status.get(\"state\") == \"Available\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e5db0ab-5dfc-4686-9245-f077faaba5f4",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert_seldon_deployment_available(SELDON_DEPLOYMENT_NAME, NAMESPACE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25c156ad-21a9-4ba8-86fb-d149f71dceca",
+   "metadata": {},
+   "source": [
+    "### Hit SeldonDeployment for Predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c358116b-609f-410a-96a5-2455f9764336",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sd = get_seldon_deployment(SELDON_DEPLOYMENT_NAME, NAMESPACE)\n",
+    "url = sd['status']['address']['url']\n",
+    "print(\"SeldonDeployment URL:\", url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc9c3b09-2f2f-4549-b0e5-458e9762fc93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inference_input = {\n",
+    "  \"data\": {\n",
+    "      \"ndarray\": [\n",
+    "          [\n",
+    "              10.1, 0.37, 0.34, 2.4, 0.085, 5.0, 17.0, 0.99683, 3.17, 0.65, 10.6\n",
+    "          ]\n",
+    "      ]\n",
+    "  }\n",
+    "}\n",
+    "response = requests.post(url, json=inference_input)\n",
+    "print(response.text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3d8af0d-7fb1-466d-acb4-e1c2bf4eb05a",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "res = response.json()\n",
+    "# verify that the predictions are as expected\n",
+    "assert res.get(\"data\") and res.get(\"data\").get(\"ndarray\"), \"Failed to get predictions!\"\n",
+    "predictions = res[\"data\"][\"ndarray\"]\n",
+    "assert len(predictions) == 1, \"Predictions not in the expected format!\"\n",
+    "assert predictions == [5.737135502528464], \"Predictions different than expected!\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3b923a8-0163-4ba9-b7f4-1c4668f5d815",
+   "metadata": {},
+   "source": [
+    "## Delete SeldonDeployment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4bc7cb5c-c5fd-4ebf-aa9c-45263ee1c049",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delete_seldon_deployment(SELDON_DEPLOYMENT_NAME, NAMESPACE);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fee424c-4500-4e00-9a03-ffd6e5d37d3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@retry(\n",
+    "    wait=wait_exponential(multiplier=2, min=1, max=10),\n",
+    "    stop=stop_after_attempt(30),\n",
+    "    reraise=True,\n",
+    ")\n",
+    "def assert_seldon_deployment_deleted(seldon_deployment_name, namespace):\n",
+    "    \"\"\"Wait for the SeldonDeployment to be deleted.\"\"\"\n",
+    "    try:\n",
+    "        # try fetching the SeldonDeployment to verify it was deleted successfully\n",
+    "        sd = get_seldon_deployment(seldon_deployment_name, namespace)\n",
+    "        assert not sd, f\"Failed to delete SeldonDeployment {seldon_deployment_name}!\"\n",
+    "    except ApiException as err:\n",
+    "        assert err.status == 404, f\"Caught unexpected exception: {err}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80723c34-cb30-47e1-acb5-b578ca5c98d2",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert_seldon_deployment_deleted(SELDON_DEPLOYMENT_NAME, NAMESPACE)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "kubeflow_notebook": {
+   "autosnapshot": false,
+   "docker_image": "afrikha/uat2:latest",
+   "experiment": {
+    "id": "",
+    "name": ""
+   },
+   "experiment_name": "",
+   "katib_metadata": {
+    "algorithm": {
+     "algorithmName": "grid"
+    },
+    "maxFailedTrialCount": 3,
+    "maxTrialCount": 12,
+    "objective": {
+     "objectiveMetricName": "",
+     "type": "minimize"
+    },
+    "parallelTrialCount": 3,
+    "parameters": []
+   },
+   "katib_run": false,
+   "pipeline_description": "",
+   "pipeline_name": "",
+   "snapshot_volumes": false,
+   "steps_defaults": [
+    "label:access-minio:true",
+    "label:access-ml-pipeline:true",
+    "label:access-mlflow:true"
+   ],
+   "volume_access_mode": "rwm",
+   "volumes": []
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Introduce notebook that combines KFP, MLFlow, and Seldon to:
* download a dataset
* clean / preprocess data
* perform training / hyper-parameter tuning with MLFlow (+ MinIO)
* serve with Seldon
* perform inference

This PR relies on the fix introduced here: https://github.com/canonical/mlflow-operator/pull/183
The `mlflow-seldon-rclone-secret` Secret can be edited directly though (and the names updated to the correct ones) if the fix is not in place.