### PR TITLE
feat: add training operator notebook tests

### DIFF
--- a/tests/notebooks/training-integration.ipynb
+++ b/tests/notebooks/training-integration.ipynb
@@ -1,0 +1,881 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test Training Operator Integration\n",
+    "\n",
+    "This example notebook is loosely based on [this](https://github.com/kubeflow/training-operator/blob/master/sdk/python/examples/kubeflow-tfjob-sdk.ipynb) upstream example.\n",
+    "\n",
+    "- create training job of type: TFJob, PyTorchJob, and PaddleJob\n",
+    "- monitor its execution\n",
+    "- get training logs\n",
+    "- delete job"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install kubeflow-training tenacity -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Import required packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kubeflow.training import (\n",
+    "    KubeflowOrgV1PaddleJob,\n",
+    "    KubeflowOrgV1PaddleJobSpec,\n",
+    "    KubeflowOrgV1PyTorchJob,\n",
+    "    KubeflowOrgV1PyTorchJobSpec,\n",
+    "    KubeflowOrgV1TFJob,\n",
+    "    KubeflowOrgV1TFJobSpec,\n",
+    "    TrainingClient,\n",
+    "    V1ReplicaSpec,\n",
+    "    V1RunPolicy,\n",
+    ")\n",
+    "from kubernetes.client import (\n",
+    "    V1Container,\n",
+    "    V1ContainerPort,\n",
+    "    V1ObjectMeta,\n",
+    "    V1PodSpec,\n",
+    "    V1PodTemplateSpec,\n",
+    ")\n",
+    "from tenacity import retry, stop_after_attempt, wait_exponential"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialise Training Client\n",
+    "\n",
+    "We will be using the Training SDK for any actions executed as part of this example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = TrainingClient()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define Helper to print training logs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_training_logs(client, job_name: str, container: str, is_master: bool = True):\n",
+    "    logs = client.get_job_logs(name=job_name, container=container, is_master=is_master)\n",
+    "    print(logs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define Helper to check that Job succeeded"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@retry(\n",
+    "    wait=wait_exponential(multiplier=2, min=1, max=30),\n",
+    "    stop=stop_after_attempt(50),\n",
+    "    reraise=True,\n",
+    ")\n",
+    "def assert_job_succeeded(client, job_name, job_kind):\n",
+    "    \"\"\"Wait for the Job to complete successfully.\"\"\"\n",
+    "    assert client.is_job_succeeded(\n",
+    "        name=job_name, job_kind=job_kind\n",
+    "    ), f\"Job {job_name} was not successful.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test TFJob"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define a TFJob\n",
+    "\n",
+    "Define a TFJob object before deploying it. This TFJob is similar to [this](https://github.com/kubeflow/training-operator/blob/master/sdk/python/examples/kubeflow-tfjob-sdk.ipynb) example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TFJOB_NAME = \"mnist\"\n",
+    "TFJOB_CONTAINER = \"tensorflow\"\n",
+    "TFJOB_IMAGE = \"gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "container = V1Container(\n",
+    "    name=TFJOB_CONTAINER,\n",
+    "    image=TFJOB_IMAGE,\n",
+    "    command=[\n",
+    "        \"python\",\n",
+    "        \"/var/tf_mnist/mnist_with_summaries.py\",\n",
+    "        \"--log_dir=/train/logs\",\n",
+    "        \"--learning_rate=0.01\",\n",
+    "        \"--batch_size=150\",\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "worker = V1ReplicaSpec(\n",
+    "    replicas=2,\n",
+    "    restart_policy=\"Never\",\n",
+    "    template=V1PodTemplateSpec(\n",
+    "        metadata=V1ObjectMeta(annotations={\"sidecar.istio.io/inject\": \"false\"}),\n",
+    "        spec=V1PodSpec(containers=[container]),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "chief = V1ReplicaSpec(\n",
+    "    replicas=1,\n",
+    "    restart_policy=\"Never\",\n",
+    "    template=V1PodTemplateSpec(\n",
+    "        metadata=V1ObjectMeta(annotations={\"sidecar.istio.io/inject\": \"false\"}),\n",
+    "        spec=V1PodSpec(containers=[container]),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "ps = V1ReplicaSpec(\n",
+    "    replicas=1,\n",
+    "    restart_policy=\"Never\",\n",
+    "    template=V1PodTemplateSpec(\n",
+    "        metadata=V1ObjectMeta(annotations={\"sidecar.istio.io/inject\": \"false\"}),\n",
+    "        spec=V1PodSpec(containers=[container]),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "tfjob = KubeflowOrgV1TFJob(\n",
+    "    api_version=\"kubeflow.org/v1\",\n",
+    "    kind=\"TFJob\",\n",
+    "    metadata=V1ObjectMeta(name=TFJOB_NAME),\n",
+    "    spec=KubeflowOrgV1TFJobSpec(\n",
+    "        run_policy=V1RunPolicy(clean_pod_policy=\"None\"),\n",
+    "        tf_replica_specs={\"Worker\": worker, \"Chief\": chief, \"PS\": ps},\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print the Job's info to verify it before submission."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Name:\", tfjob.metadata.name)\n",
+    "print(\"Spec:\", tfjob.spec.tf_replica_specs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### List existing TFJobs\n",
+    "\n",
+    "List TFJobs in the current namespace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[job.metadata.name for job in client.list_tfjobs()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create TFJob\n",
+    "\n",
+    "Create a TFJob using the SDK."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.create_tfjob(tfjob)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Get TFJob\n",
+    "Get the created TFJob by name and check its data.  \n",
+    "Make sure that it completes successfully before proceeding. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# verify that the Job was created successfully\n",
+    "# raises an error if it doesn't exist\n",
+    "tfjob = client.get_tfjob(name=TFJOB_NAME)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# wait for the Job to complete successfully\n",
+    "assert_job_succeeded(client, TFJOB_NAME, job_kind=\"TFJob\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Job:\", tfjob.metadata.name, end=\"\\n\\n\")\n",
+    "print(\"Job Spec:\", tfjob.spec, sep=\"\\n\", end=\"\\n\\n\")\n",
+    "print(\"Job Status:\", tfjob.status, sep=\"\\n\", end=\"\\n\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get TFJob Training logs\n",
+    "Get and print the training logs of the TFJob with the training steps "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_training_logs(client, TFJOB_NAME, container=TFJOB_CONTAINER)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Delete TFJob\n",
+    "\n",
+    "Delete the created TFJob."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.delete_tfjob(name=TFJOB_NAME)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@retry(\n",
+    "    wait=wait_exponential(multiplier=2, min=1, max=10),\n",
+    "    stop=stop_after_attempt(30),\n",
+    "    reraise=True,\n",
+    ")\n",
+    "def assert_tfjob_removed(client, job_name):\n",
+    "    \"\"\"Wait for TFJob to be removed.\"\"\"\n",
+    "    # fetch the existing TFJob names\n",
+    "    # verify that the Job was deleted successfully\n",
+    "    jobs = {job.metadata.name for job in client.list_tfjobs()}\n",
+    "    assert job_name not in jobs, f\"Failed to delete TFJob {job_name}!\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# wait for TFJob resources to be removed successfully\n",
+    "assert_tfjob_removed(client, TFJOB_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test PyTorchJob"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define a PyTorchJob\n",
+    "Define a PyTorchJob object before deploying it. This PyTorchJob is similar to [this](https://github.com/kubeflow/training-operator/blob/11b7a115e6538caeab405344af98f0d5b42a4c96/sdk/python/examples/kubeflow-pytorchjob-sdk.ipynb) example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PYTORCHJOB_NAME = \"pytorch-dist-mnist-gloo\"\n",
+    "PYTORCHJOB_CONTAINER = \"pytorch\"\n",
+    "PYTORCHJOB_IMAGE = \"gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "container = V1Container(\n",
+    "    name=PYTORCHJOB_CONTAINER,\n",
+    "    image=PYTORCHJOB_IMAGE,\n",
+    "    args=[\"--backend\", \"gloo\"],\n",
+    ")\n",
+    "\n",
+    "replica_spec = V1ReplicaSpec(\n",
+    "    replicas=1,\n",
+    "    restart_policy=\"OnFailure\",\n",
+    "    template=V1PodTemplateSpec(\n",
+    "        metadata=V1ObjectMeta(annotations={\"sidecar.istio.io/inject\": \"false\"}),\n",
+    "        spec=V1PodSpec(containers=[container]),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "pytorchjob = KubeflowOrgV1PyTorchJob(\n",
+    "    api_version=\"kubeflow.org/v1\",\n",
+    "    kind=\"PyTorchJob\",\n",
+    "    metadata=V1ObjectMeta(name=PYTORCHJOB_NAME),\n",
+    "    spec=KubeflowOrgV1PyTorchJobSpec(\n",
+    "        run_policy=V1RunPolicy(clean_pod_policy=\"None\"),\n",
+    "        pytorch_replica_specs={\"Master\": replica_spec, \"Worker\": replica_spec},\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print the Job's info to verify it before submission."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Name:\", pytorchjob.metadata.name)\n",
+    "print(\"Spec:\", pytorchjob.spec.pytorch_replica_specs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### List existing PyTorchJobs\n",
+    "\n",
+    "List PyTorchJobs in the current namespace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[job.metadata.name for job in client.list_pytorchjobs()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create PyTorchJob\n",
+    "\n",
+    "Create a PyTorchJob using the SDK."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.create_pytorchjob(pytorchjob)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Get PyTorchJob\n",
+    "Get the created PyTorchJob by name and check its data.  \n",
+    "Make sure that it completes successfully before proceeding. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# verify that the Job was created successfully\n",
+    "# raises an error if it doesn't exist\n",
+    "pytorchjob = client.get_pytorchjob(name=PYTORCHJOB_NAME)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# wait for the Job to complete successfully\n",
+    "assert_job_succeeded(client, PYTORCHJOB_NAME, job_kind=\"PyTorchJob\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Job:\", pytorchjob.metadata.name, end=\"\\n\\n\")\n",
+    "print(\"Job Spec:\", pytorchjob.spec, sep=\"\\n\", end=\"\\n\\n\")\n",
+    "print(\"Job Status:\", pytorchjob.status, sep=\"\\n\", end=\"\\n\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get PyTorchJob Training logs\n",
+    "Get and print the training logs of the PyTorchJob with the training steps "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_training_logs(client, PYTORCHJOB_NAME, container=PYTORCHJOB_CONTAINER)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Delete PyTorchJob\n",
+    "\n",
+    "Delete the created PyTorchJob."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.delete_pytorchjob(name=PYTORCHJOB_NAME)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@retry(\n",
+    "    wait=wait_exponential(multiplier=2, min=1, max=10),\n",
+    "    stop=stop_after_attempt(30),\n",
+    "    reraise=True,\n",
+    ")\n",
+    "def assert_pytorchjob_removed(client, job_name):\n",
+    "    \"\"\"Wait for PyTorchJob to be removed.\"\"\"\n",
+    "    # fetch the existing PyTorchJob names\n",
+    "    # verify that the Job was deleted successfully\n",
+    "    jobs = {job.metadata.name for job in client.list_pytorchjobs()}\n",
+    "    assert job_name not in jobs, f\"Failed to delete PyTorchJob {job_name}!\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# wait for PyTorch job to be removed successfully\n",
+    "assert_pytorchjob_removed(client, PYTORCHJOB_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test PaddlePaddle"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define a PaddleJob\n",
+    "\n",
+    "Define a PaddleJob object before deploying it. This PaddleJob is loosely based on [this](https://github.com/kubeflow/training-operator/blob/11b7a115e6538caeab405344af98f0d5b42a4c96/examples/paddlepaddle/simple-cpu.yaml) example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PADDLEJOB_NAME = \"paddle-simple-cpu\"\n",
+    "PADDLEJOB_CONTAINER = \"paddle\"\n",
+    "PADDLEJOB_IMAGE = \"registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-cpu\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "port = V1ContainerPort(container_port=37777, name=\"master\")\n",
+    "\n",
+    "container = V1Container(\n",
+    "    name=PADDLEJOB_CONTAINER,\n",
+    "    image=PADDLEJOB_IMAGE,\n",
+    "    command=[\"python\"],\n",
+    "    args=[\"-m\", \"paddle.distributed.launch\", \"run_check\"],\n",
+    "    ports=[port],\n",
+    ")\n",
+    "\n",
+    "replica_spec = V1ReplicaSpec(\n",
+    "    replicas=2,\n",
+    "    restart_policy=\"OnFailure\",\n",
+    "    template=V1PodTemplateSpec(\n",
+    "        metadata=V1ObjectMeta(annotations={\"sidecar.istio.io/inject\": \"false\"}),\n",
+    "        spec=V1PodSpec(containers=[container]),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "paddlejob = KubeflowOrgV1PaddleJob(\n",
+    "    api_version=\"kubeflow.org/v1\",\n",
+    "    kind=\"PaddleJob\",\n",
+    "    metadata=V1ObjectMeta(name=PADDLEJOB_NAME),\n",
+    "    spec=KubeflowOrgV1PaddleJobSpec(\n",
+    "        run_policy=V1RunPolicy(clean_pod_policy=\"None\"),\n",
+    "        paddle_replica_specs={\"Worker\": replica_spec},\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print the Job's info to verify it before submission."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Name:\", paddlejob.metadata.name)\n",
+    "print(\"Spec:\", paddlejob.spec.paddle_replica_specs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### List existing PaddleJobs\n",
+    "\n",
+    "List PaddleJobs in the current namespace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[job.metadata.name for job in client.list_paddlejobs()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create PaddleJob\n",
+    "\n",
+    "Create a PaddleJob using the SDK."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.create_paddlejob(paddlejob)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Get PaddleJob\n",
+    "Get the created PaddleJob by name and check its data.  \n",
+    "Make sure that it completes successfully before proceeding. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# verify that the Job was created successfully\n",
+    "# raises an error if it doesn't exist\n",
+    "paddlejob = client.get_paddlejob(name=PADDLEJOB_NAME)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# wait for the Job to complete successfully\n",
+    "assert_job_succeeded(client, PADDLEJOB_NAME, job_kind=\"PaddleJob\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Job:\", paddlejob.metadata.name, end=\"\\n\\n\")\n",
+    "print(\"Job Spec:\", paddlejob.spec, sep=\"\\n\", end=\"\\n\\n\")\n",
+    "print(\"Job Status:\", paddlejob.status, sep=\"\\n\", end=\"\\n\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get PaddleJob Training logs\n",
+    "Get and print the training logs of the PaddleJob with the training steps "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set is_master to False because this example does not include a master replica type\n",
+    "print_training_logs(client, PADDLEJOB_NAME, container=PADDLEJOB_CONTAINER, is_master=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Delete PaddleJob\n",
+    "\n",
+    "Delete the created PaddleJob."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.delete_paddlejob(name=PADDLEJOB_NAME)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@retry(\n",
+    "    wait=wait_exponential(multiplier=2, min=1, max=10),\n",
+    "    stop=stop_after_attempt(30),\n",
+    "    reraise=True,\n",
+    ")\n",
+    "def assert_paddlejob_removed(client, job_name):\n",
+    "    \"\"\"Wait for PaddleJob to be removed.\"\"\"\n",
+    "    # fetch the existing PaddleJob names\n",
+    "    # verify that the Job was deleted successfully\n",
+    "    jobs = {job.metadata.name for job in client.list_paddlejobs()}\n",
+    "    assert job_name not in jobs, f\"Failed to delete PaddleJob {job_name}!\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# wait for PaddleJob to be removed successfully\n",
+    "assert_paddlejob_removed(client, PADDLEJOB_NAME)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Introduce Notebook to test training operator integration

## Summary of tests
- create training job of type: TFJob, PyTorchJob, and PaddleJob
- monitor its execution
- get training logs
- delete job

Test Training Operator Integration
This example notebook is loosely based on [this](https://github.com/kubeflow/training-operator/blob/master/sdk/python/examples/kubeflow-tfjob-sdk.ipynb) upstream example.

<details><summary>Test run summary with pytest-operator</summary>
<p>
tox -e uats -- --filter "training"

============================= test session starts ==============================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.2.0 -- /opt/conda/bin/python3.8
cachedir: .pytest_cache
rootdir: /tests
configfile: pytest.ini
plugins: anyio-3.6.2
collecting ... collected 7 items / 6 deselected / 1 selected

test_notebooks.py::test_notebook[training-integration] 
-------------------------------- live log call ---------------------------------
INFO     test_notebooks:test_notebooks.py:37 Running training-integration.ipynb...
PASSED                                                                   [100%]

================= 1 passed, 6 deselected in 731.27s (0:12:11) ==================
PASSED
--------------------------------------------------------------------------------------------------- live log teardown ---------------------------------------------------------------------------------------------------
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:72 Deleting Profile test-kubeflow...
INFO     httpx:_client.py:1013 HTTP Request: DELETE https://172.31.24.4:16443/apis/kubeflow.org/v1/profiles/test-kubeflow "HTTP/1.1 200 OK"
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:129 Deleting Job test-kubeflow/test-kubeflow...
INFO     httpx:_client.py:1013 HTTP Request: DELETE https://172.31.24.4:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"


============================================================================================= 2 passed in 771.10s (0:12:51) =============================================================================================
________________________________________________________________________________________________________ summary ________________________________________________________________________________________________________
  uats: commands succeeded
  congratulations :)
</p></details>
<details><summary>Notebook with execution logs</summary>
<p>
create training job of type: TFJob, PyTorchJob, and PaddleJob
monitor its execution
get training logs
delete job
Setup
!pip install kubeflow-training tenacity -q
Import required packages
from kubernetes.client import V1PodTemplateSpec
from kubernetes.client import V1ObjectMeta
from kubernetes.client import V1PodSpec
from kubernetes.client import V1Container
from kubernetes.client import V1ContainerPort

from kubeflow.training import constants
from kubeflow.training.utils import utils
from kubeflow.training import V1ReplicaSpec
from kubeflow.training import KubeflowOrgV1TFJob
from kubeflow.training import KubeflowOrgV1TFJobSpec
from kubeflow.training import KubeflowOrgV1PyTorchJob
from kubeflow.training import KubeflowOrgV1PyTorchJobSpec
from kubeflow.training import KubeflowOrgV1PaddleJob
from kubeflow.training import KubeflowOrgV1PaddleJobSpec
from kubeflow.training import V1RunPolicy
from kubeflow.training import TrainingClient

from tenacity import retry, stop_after_attempt, wait_exponential
Initialise Training Client
We will be using the Training SDK for any actions executed as part of this example.

client = TrainingClient()
Define Helper to print training logs
def print_training_logs(client, job_name: str, container: str, is_master: bool = True):
    logs = client.get_job_logs(name=job_name, container=container, is_master=is_master)
    print(logs)
Define Helper to check that Job succeeded
@retry(
    wait=wait_exponential(multiplier=2, min=1, max=30),
    stop=stop_after_attempt(50),
    reraise=True,
)
def assert_job_succeeded(client, job_name, job_kind):
    """Wait for the Job to complete successfully."""
    assert client.is_job_succeeded(
        name=job_name, job_kind=job_kind
    ), f"Job {job_name} was not successful."
Test TFJob
Define a TFJob
Define a TFJob object before deploying it. This TFJob is similar to [this](https://github.com/kubeflow/training-operator/blob/master/sdk/python/examples/kubeflow-tfjob-sdk.ipynb) example.

TFJOB_NAME = "mnist"
container = V1Container(
    name="tensorflow",
    image="gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0",
    command=[
        "python",
        "/var/tf_mnist/mnist_with_summaries.py",
        "--log_dir=/train/logs",
        "--learning_rate=0.01",
        "--batch_size=150",
    ],
)

worker = V1ReplicaSpec(
    replicas=2,
    restart_policy="Never",
    template=V1PodTemplateSpec(
        metadata=V1ObjectMeta(annotations={"sidecar.istio.io/inject": "false"}),
        spec=V1PodSpec(containers=[container]),
    ),
)

chief = V1ReplicaSpec(
    replicas=1,
    restart_policy="Never",
    template=V1PodTemplateSpec(
        metadata=V1ObjectMeta(annotations={"sidecar.istio.io/inject": "false"}),
        spec=V1PodSpec(containers=[container]),
    ),
)

ps = V1ReplicaSpec(
    replicas=1,
    restart_policy="Never",
    template=V1PodTemplateSpec(
        metadata=V1ObjectMeta(annotations={"sidecar.istio.io/inject": "false"}),
        spec=V1PodSpec(containers=[container]),
    ),
)

tfjob = KubeflowOrgV1TFJob(
    api_version="kubeflow.org/v1",
    kind="TFJob",
    metadata=V1ObjectMeta(name=TFJOB_NAME),
    spec=KubeflowOrgV1TFJobSpec(
        run_policy=V1RunPolicy(clean_pod_policy="None"),
        tf_replica_specs={"Worker": worker, "Chief": chief, "PS": ps},
    ),
)
Print the Job's info to verify it before submission.

print("Name:", tfjob.metadata.name)
print("Spec:", tfjob.spec.tf_replica_specs)
Name: mnist
Spec: {'Worker': {'replicas': 2,
 'restart_policy': 'Never',
 'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                           'creation_timestamp': None,
                           'deletion_grace_period_seconds': None,
                           'deletion_timestamp': None,
                           'finalizers': None,
                           'generate_name': None,
                           'generation': None,
                           'labels': None,
                           'managed_fields': None,
                           'name': None,
                           'namespace': None,
                           'owner_references': None,
                           'resource_version': None,
                           'self_link': None,
                           'uid': None},
              'spec': {'active_deadline_seconds': None,
                       'affinity': None,
                       'automount_service_account_token': None,
                       'containers': [{'args': None,
                                       'command': ['python',
                                                   '/var/tf_mnist/mnist_with_summaries.py',
                                                   '--log_dir=/train/logs',
                                                   '--learning_rate=0.01',
                                                   '--batch_size=150'],
                                       'env': None,
                                       'env_from': None,
                                       'image': 'gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0',
                                       'image_pull_policy': None,
                                       'lifecycle': None,
                                       'liveness_probe': None,
                                       'name': 'tensorflow',
                                       'ports': None,
                                       'readiness_probe': None,
                                       'resize_policy': None,
                                       'resources': None,
                                       'security_context': None,
                                       'startup_probe': None,
                                       'stdin': None,
                                       'stdin_once': None,
                                       'termination_message_path': None,
                                       'termination_message_policy': None,
                                       'tty': None,
                                       'volume_devices': None,
                                       'volume_mounts': None,
                                       'working_dir': None}],
                       'dns_config': None,
                       'dns_policy': None,
                       'enable_service_links': None,
                       'ephemeral_containers': None,
                       'host_aliases': None,
                       'host_ipc': None,
                       'host_network': None,
                       'host_pid': None,
                       'host_users': None,
                       'hostname': None,
                       'image_pull_secrets': None,
                       'init_containers': None,
                       'node_name': None,
                       'node_selector': None,
                       'os': None,
                       'overhead': None,
                       'preemption_policy': None,
                       'priority': None,
                       'priority_class_name': None,
                       'readiness_gates': None,
                       'resource_claims': None,
                       'restart_policy': None,
                       'runtime_class_name': None,
                       'scheduler_name': None,
                       'scheduling_gates': None,
                       'security_context': None,
                       'service_account': None,
                       'service_account_name': None,
                       'set_hostname_as_fqdn': None,
                       'share_process_namespace': None,
                       'subdomain': None,
                       'termination_grace_period_seconds': None,
                       'tolerations': None,
                       'topology_spread_constraints': None,
                       'volumes': None}}}, 'Chief': {'replicas': 1,
 'restart_policy': 'Never',
 'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                           'creation_timestamp': None,
                           'deletion_grace_period_seconds': None,
                           'deletion_timestamp': None,
                           'finalizers': None,
                           'generate_name': None,
                           'generation': None,
                           'labels': None,
                           'managed_fields': None,
                           'name': None,
                           'namespace': None,
                           'owner_references': None,
                           'resource_version': None,
                           'self_link': None,
                           'uid': None},
              'spec': {'active_deadline_seconds': None,
                       'affinity': None,
                       'automount_service_account_token': None,
                       'containers': [{'args': None,
                                       'command': ['python',
                                                   '/var/tf_mnist/mnist_with_summaries.py',
                                                   '--log_dir=/train/logs',
                                                   '--learning_rate=0.01',
                                                   '--batch_size=150'],
                                       'env': None,
                                       'env_from': None,
                                       'image': 'gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0',
                                       'image_pull_policy': None,
                                       'lifecycle': None,
                                       'liveness_probe': None,
                                       'name': 'tensorflow',
                                       'ports': None,
                                       'readiness_probe': None,
                                       'resize_policy': None,
                                       'resources': None,
                                       'security_context': None,
                                       'startup_probe': None,
                                       'stdin': None,
                                       'stdin_once': None,
                                       'termination_message_path': None,
                                       'termination_message_policy': None,
                                       'tty': None,
                                       'volume_devices': None,
                                       'volume_mounts': None,
                                       'working_dir': None}],
                       'dns_config': None,
                       'dns_policy': None,
                       'enable_service_links': None,
                       'ephemeral_containers': None,
                       'host_aliases': None,
                       'host_ipc': None,
                       'host_network': None,
                       'host_pid': None,
                       'host_users': None,
                       'hostname': None,
                       'image_pull_secrets': None,
                       'init_containers': None,
                       'node_name': None,
                       'node_selector': None,
                       'os': None,
                       'overhead': None,
                       'preemption_policy': None,
                       'priority': None,
                       'priority_class_name': None,
                       'readiness_gates': None,
                       'resource_claims': None,
                       'restart_policy': None,
                       'runtime_class_name': None,
                       'scheduler_name': None,
                       'scheduling_gates': None,
                       'security_context': None,
                       'service_account': None,
                       'service_account_name': None,
                       'set_hostname_as_fqdn': None,
                       'share_process_namespace': None,
                       'subdomain': None,
                       'termination_grace_period_seconds': None,
                       'tolerations': None,
                       'topology_spread_constraints': None,
                       'volumes': None}}}, 'PS': {'replicas': 1,
 'restart_policy': 'Never',
 'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                           'creation_timestamp': None,
                           'deletion_grace_period_seconds': None,
                           'deletion_timestamp': None,
                           'finalizers': None,
                           'generate_name': None,
                           'generation': None,
                           'labels': None,
                           'managed_fields': None,
                           'name': None,
                           'namespace': None,
                           'owner_references': None,
                           'resource_version': None,
                           'self_link': None,
                           'uid': None},
              'spec': {'active_deadline_seconds': None,
                       'affinity': None,
                       'automount_service_account_token': None,
                       'containers': [{'args': None,
                                       'command': ['python',
                                                   '/var/tf_mnist/mnist_with_summaries.py',
                                                   '--log_dir=/train/logs',
                                                   '--learning_rate=0.01',
                                                   '--batch_size=150'],
                                       'env': None,
                                       'env_from': None,
                                       'image': 'gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0',
                                       'image_pull_policy': None,
                                       'lifecycle': None,
                                       'liveness_probe': None,
                                       'name': 'tensorflow',
                                       'ports': None,
                                       'readiness_probe': None,
                                       'resize_policy': None,
                                       'resources': None,
                                       'security_context': None,
                                       'startup_probe': None,
                                       'stdin': None,
                                       'stdin_once': None,
                                       'termination_message_path': None,
                                       'termination_message_policy': None,
                                       'tty': None,
                                       'volume_devices': None,
                                       'volume_mounts': None,
                                       'working_dir': None}],
                       'dns_config': None,
                       'dns_policy': None,
                       'enable_service_links': None,
                       'ephemeral_containers': None,
                       'host_aliases': None,
                       'host_ipc': None,
                       'host_network': None,
                       'host_pid': None,
                       'host_users': None,
                       'hostname': None,
                       'image_pull_secrets': None,
                       'init_containers': None,
                       'node_name': None,
                       'node_selector': None,
                       'os': None,
                       'overhead': None,
                       'preemption_policy': None,
                       'priority': None,
                       'priority_class_name': None,
                       'readiness_gates': None,
                       'resource_claims': None,
                       'restart_policy': None,
                       'runtime_class_name': None,
                       'scheduler_name': None,
                       'scheduling_gates': None,
                       'security_context': None,
                       'service_account': None,
                       'service_account_name': None,
                       'set_hostname_as_fqdn': None,
                       'share_process_namespace': None,
                       'subdomain': None,
                       'termination_grace_period_seconds': None,
                       'tolerations': None,
                       'topology_spread_constraints': None,
                       'volumes': None}}}}
List existing TFJob
List TFJobs in the current namespace.

[job.metadata.name for job in client.list_tfjobs()]
[]
Create TFJob
Create a TFJob using the SDK.

client.create_tfjob(tfjob)
TFJob admin/mnist has been created
Get TFJob
Get the created TFJob by name and check its data.
Make sure that it completes successfully before proceeding.

# verify that the Job was created successfully
# raises an error if it doesn't exist
client.get_tfjob(name=TFJOB_NAME);
# wait for the Job to complete successfully
assert_job_succeeded(client, TFJOB_NAME, job_kind="TFJob")
job = client.get_tfjob(name=TFJOB_NAME)
print("Job:", job.metadata.name, end="\n\n")
print("Job Spec:", job.spec, sep="\n", end="\n\n")
print("Job Status:", job.status, sep="\n", end="\n\n")
Job: mnist

Job Spec:
{'enable_dynamic_worker': None,
 'run_policy': {'active_deadline_seconds': None,
                'backoff_limit': None,
                'clean_pod_policy': 'None',
                'scheduling_policy': None,
                'ttl_seconds_after_finished': None},
 'success_policy': None,
 'tf_replica_specs': {'Chief': {'replicas': 1,
                                'restart_policy': 'Never',
                                'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                                                          'creation_timestamp': None,
                                                          'deletion_grace_period_seconds': None,
                                                          'deletion_timestamp': None,
                                                          'finalizers': None,
                                                          'generate_name': None,
                                                          'generation': None,
                                                          'labels': None,
                                                          'managed_fields': None,
                                                          'name': None,
                                                          'namespace': None,
                                                          'owner_references': None,
                                                          'resource_version': None,
                                                          'self_link': None,
                                                          'uid': None},
                                             'spec': {'active_deadline_seconds': None,
                                                      'affinity': None,
                                                      'automount_service_account_token': None,
                                                      'containers': [{'args': None,
                                                                      'command': ['python',
                                                                                  '/var/tf_mnist/mnist_with_summaries.py',
                                                                                  '--log_dir=/train/logs',
                                                                                  '--learning_rate=0.01',
                                                                                  '--batch_size=150'],
                                                                      'env': None,
                                                                      'env_from': None,
                                                                      'image': 'gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0',
                                                                      'image_pull_policy': None,
                                                                      'lifecycle': None,
                                                                      'liveness_probe': None,
                                                                      'name': 'tensorflow',
                                                                      'ports': None,
                                                                      'readiness_probe': None,
                                                                      'resize_policy': None,
                                                                      'resources': None,
                                                                      'security_context': None,
                                                                      'startup_probe': None,
                                                                      'stdin': None,
                                                                      'stdin_once': None,
                                                                      'termination_message_path': None,
                                                                      'termination_message_policy': None,
                                                                      'tty': None,
                                                                      'volume_devices': None,
                                                                      'volume_mounts': None,
                                                                      'working_dir': None}],
                                                      'dns_config': None,
                                                      'dns_policy': None,
                                                      'enable_service_links': None,
                                                      'ephemeral_containers': None,
                                                      'host_aliases': None,
                                                      'host_ipc': None,
                                                      'host_network': None,
                                                      'host_pid': None,
                                                      'host_users': None,
                                                      'hostname': None,
                                                      'image_pull_secrets': None,
                                                      'init_containers': None,
                                                      'node_name': None,
                                                      'node_selector': None,
                                                      'os': None,
                                                      'overhead': None,
                                                      'preemption_policy': None,
                                                      'priority': None,
                                                      'priority_class_name': None,
                                                      'readiness_gates': None,
                                                      'resource_claims': None,
                                                      'restart_policy': None,
                                                      'runtime_class_name': None,
                                                      'scheduler_name': None,
                                                      'scheduling_gates': None,
                                                      'security_context': None,
                                                      'service_account': None,
                                                      'service_account_name': None,
                                                      'set_hostname_as_fqdn': None,
                                                      'share_process_namespace': None,
                                                      'subdomain': None,
                                                      'termination_grace_period_seconds': None,
                                                      'tolerations': None,
                                                      'topology_spread_constraints': None,
                                                      'volumes': None}}},
                      'PS': {'replicas': 1,
                             'restart_policy': 'Never',
                             'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                                                       'creation_timestamp': None,
                                                       'deletion_grace_period_seconds': None,
                                                       'deletion_timestamp': None,
                                                       'finalizers': None,
                                                       'generate_name': None,
                                                       'generation': None,
                                                       'labels': None,
                                                       'managed_fields': None,
                                                       'name': None,
                                                       'namespace': None,
                                                       'owner_references': None,
                                                       'resource_version': None,
                                                       'self_link': None,
                                                       'uid': None},
                                          'spec': {'active_deadline_seconds': None,
                                                   'affinity': None,
                                                   'automount_service_account_token': None,
                                                   'containers': [{'args': None,
                                                                   'command': ['python',
                                                                               '/var/tf_mnist/mnist_with_summaries.py',
                                                                               '--log_dir=/train/logs',
                                                                               '--learning_rate=0.01',
                                                                               '--batch_size=150'],
                                                                   'env': None,
                                                                   'env_from': None,
                                                                   'image': 'gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0',
                                                                   'image_pull_policy': None,
                                                                   'lifecycle': None,
                                                                   'liveness_probe': None,
                                                                   'name': 'tensorflow',
                                                                   'ports': None,
                                                                   'readiness_probe': None,
                                                                   'resize_policy': None,
                                                                   'resources': None,
                                                                   'security_context': None,
                                                                   'startup_probe': None,
                                                                   'stdin': None,
                                                                   'stdin_once': None,
                                                                   'termination_message_path': None,
                                                                   'termination_message_policy': None,
                                                                   'tty': None,
                                                                   'volume_devices': None,
                                                                   'volume_mounts': None,
                                                                   'working_dir': None}],
                                                   'dns_config': None,
                                                   'dns_policy': None,
                                                   'enable_service_links': None,
                                                   'ephemeral_containers': None,
                                                   'host_aliases': None,
                                                   'host_ipc': None,
                                                   'host_network': None,
                                                   'host_pid': None,
                                                   'host_users': None,
                                                   'hostname': None,
                                                   'image_pull_secrets': None,
                                                   'init_containers': None,
                                                   'node_name': None,
                                                   'node_selector': None,
                                                   'os': None,
                                                   'overhead': None,
                                                   'preemption_policy': None,
                                                   'priority': None,
                                                   'priority_class_name': None,
                                                   'readiness_gates': None,
                                                   'resource_claims': None,
                                                   'restart_policy': None,
                                                   'runtime_class_name': None,
                                                   'scheduler_name': None,
                                                   'scheduling_gates': None,
                                                   'security_context': None,
                                                   'service_account': None,
                                                   'service_account_name': None,
                                                   'set_hostname_as_fqdn': None,
                                                   'share_process_namespace': None,
                                                   'subdomain': None,
                                                   'termination_grace_period_seconds': None,
                                                   'tolerations': None,
                                                   'topology_spread_constraints': None,
                                                   'volumes': None}}},
                      'Worker': {'replicas': 2,
                                 'restart_policy': 'Never',
                                 'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                                                           'creation_timestamp': None,
                                                           'deletion_grace_period_seconds': None,
                                                           'deletion_timestamp': None,
                                                           'finalizers': None,
                                                           'generate_name': None,
                                                           'generation': None,
                                                           'labels': None,
                                                           'managed_fields': None,
                                                           'name': None,
                                                           'namespace': None,
                                                           'owner_references': None,
                                                           'resource_version': None,
                                                           'self_link': None,
                                                           'uid': None},
                                              'spec': {'active_deadline_seconds': None,
                                                       'affinity': None,
                                                       'automount_service_account_token': None,
                                                       'containers': [{'args': None,
                                                                       'command': ['python',
                                                                                   '/var/tf_mnist/mnist_with_summaries.py',
                                                                                   '--log_dir=/train/logs',
                                                                                   '--learning_rate=0.01',
                                                                                   '--batch_size=150'],
                                                                       'env': None,
                                                                       'env_from': None,
                                                                       'image': 'gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0',
                                                                       'image_pull_policy': None,
                                                                       'lifecycle': None,
                                                                       'liveness_probe': None,
                                                                       'name': 'tensorflow',
                                                                       'ports': None,
                                                                       'readiness_probe': None,
                                                                       'resize_policy': None,
                                                                       'resources': None,
                                                                       'security_context': None,
                                                                       'startup_probe': None,
                                                                       'stdin': None,
                                                                       'stdin_once': None,
                                                                       'termination_message_path': None,
                                                                       'termination_message_policy': None,
                                                                       'tty': None,
                                                                       'volume_devices': None,
                                                                       'volume_mounts': None,
                                                                       'working_dir': None}],
                                                       'dns_config': None,
                                                       'dns_policy': None,
                                                       'enable_service_links': None,
                                                       'ephemeral_containers': None,
                                                       'host_aliases': None,
                                                       'host_ipc': None,
                                                       'host_network': None,
                                                       'host_pid': None,
                                                       'host_users': None,
                                                       'hostname': None,
                                                       'image_pull_secrets': None,
                                                       'init_containers': None,
                                                       'node_name': None,
                                                       'node_selector': None,
                                                       'os': None,
                                                       'overhead': None,
                                                       'preemption_policy': None,
                                                       'priority': None,
                                                       'priority_class_name': None,
                                                       'readiness_gates': None,
                                                       'resource_claims': None,
                                                       'restart_policy': None,
                                                       'runtime_class_name': None,
                                                       'scheduler_name': None,
                                                       'scheduling_gates': None,
                                                       'security_context': None,
                                                       'service_account': None,
                                                       'service_account_name': None,
                                                       'set_hostname_as_fqdn': None,
                                                       'share_process_namespace': None,
                                                       'subdomain': None,
                                                       'termination_grace_period_seconds': None,
                                                       'tolerations': None,
                                                       'topology_spread_constraints': None,
                                                       'volumes': None}}}}}

Job Status:
{'completion_time': datetime.datetime(2023, 8, 23, 14, 52, 33, tzinfo=tzlocal()),
 'conditions': [{'last_transition_time': datetime.datetime(2023, 8, 23, 14, 50, 2, tzinfo=tzlocal()),
                 'last_update_time': datetime.datetime(2023, 8, 23, 14, 50, 2, tzinfo=tzlocal()),
                 'message': 'TFJob mnist is created.',
                 'reason': 'TFJobCreated',
                 'status': 'True',
                 'type': 'Created'},
                {'last_transition_time': datetime.datetime(2023, 8, 23, 14, 50, 9, tzinfo=tzlocal()),
                 'last_update_time': datetime.datetime(2023, 8, 23, 14, 50, 9, tzinfo=tzlocal()),
                 'message': 'TFJob admin/mnist is running.',
                 'reason': 'TFJobRunning',
                 'status': 'False',
                 'type': 'Running'},
                {'last_transition_time': datetime.datetime(2023, 8, 23, 14, 52, 33, tzinfo=tzlocal()),
                 'last_update_time': datetime.datetime(2023, 8, 23, 14, 52, 33, tzinfo=tzlocal()),
                 'message': 'TFJob admin/mnist successfully completed.',
                 'reason': 'TFJobSucceeded',
                 'status': 'True',
                 'type': 'Succeeded'}],
 'last_reconcile_time': None,
 'replica_statuses': {'Chief': {'active': None,
                                'failed': None,
                                'label_selector': None,
                                'selector': None,
                                'succeeded': 1},
                      'PS': {'active': None,
                             'failed': None,
                             'label_selector': None,
                             'selector': None,
                             'succeeded': 1},
                      'Worker': {'active': None,
                                 'failed': None,
                                 'label_selector': None,
                                 'selector': None,
                                 'succeeded': 2}},
 'start_time': datetime.datetime(2023, 8, 23, 14, 50, 9, tzinfo=tzlocal())}

Get TFJob Training logs
Get and print the training logs of the TFJob with the training steps

print_training_logs(client, TFJOB_NAME, container="tensorflow")
The logs of pod mnist-chief-0:
 WARNING:tensorflow:From /var/tf_mnist/mnist_with_summaries.py:39: read_data_sets (from tensorflow.contrib.learn.python.learn.datasets.mnist) is deprecated and will be removed in a future version.
Instructions for updating:
Please use alternatives such as official/mnist/dataset.py from tensorflow/models.
WARNING:tensorflow:From /usr/local/lib/python2.7/dist-packages/tensorflow/contrib/learn/python/learn/datasets/mnist.py:260: maybe_download (from tensorflow.contrib.learn.python.learn.datasets.base) is deprecated and will be removed in a future version.
Instructions for updating:
Please write your own downloading logic.
WARNING:tensorflow:From /usr/local/lib/python2.7/dist-packages/tensorflow/contrib/learn/python/learn/datasets/base.py:252: wrapped_fn (from tensorflow.contrib.learn.python.learn.datasets.base) is deprecated and will be removed in a future version.
Instructions for updating:
Please use urllib or similar directly.
WARNING:tensorflow:From /usr/local/lib/python2.7/dist-packages/tensorflow/contrib/learn/python/learn/datasets/mnist.py:262: extract_images (from tensorflow.contrib.learn.python.learn.datasets.mnist) is deprecated and will be removed in a future version.
Instructions for updating:
Please use tf.data to implement this functionality.
WARNING:tensorflow:From /usr/local/lib/python2.7/dist-packages/tensorflow/contrib/learn/python/learn/datasets/mnist.py:267: extract_labels (from tensorflow.contrib.learn.python.learn.datasets.mnist) is deprecated and will be removed in a future version.
Instructions for updating:
Please use tf.data to implement this functionality.
WARNING:tensorflow:From /usr/local/lib/python2.7/dist-packages/tensorflow/contrib/learn/python/learn/datasets/mnist.py:290: __init__ (from tensorflow.contrib.learn.python.learn.datasets.mnist) is deprecated and will be removed in a future version.
Instructions for updating:
Please use alternatives such as official/mnist/dataset.py from tensorflow/models.
2023-08-23 14:50:10.879767: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 AVX512F FMA
Successfully downloaded train-images-idx3-ubyte.gz 9912422 bytes.
Extracting /tmp/tensorflow/mnist/input_data/train-images-idx3-ubyte.gz
Successfully downloaded train-labels-idx1-ubyte.gz 28881 bytes.
Extracting /tmp/tensorflow/mnist/input_data/train-labels-idx1-ubyte.gz
Successfully downloaded t10k-images-idx3-ubyte.gz 1648877 bytes.
Extracting /tmp/tensorflow/mnist/input_data/t10k-images-idx3-ubyte.gz
Successfully downloaded t10k-labels-idx1-ubyte.gz 4542 bytes.
Extracting /tmp/tensorflow/mnist/input_data/t10k-labels-idx1-ubyte.gz
Accuracy at step 0: 0.1223
Accuracy at step 10: 0.8079
Accuracy at step 20: 0.8813
Accuracy at step 30: 0.9071
Accuracy at step 40: 0.9138
Accuracy at step 50: 0.9215
Accuracy at step 60: 0.9244
Accuracy at step 70: 0.9285
Accuracy at step 80: 0.9358
Accuracy at step 90: 0.935
Adding run metadata for 99
Accuracy at step 100: 0.94
Accuracy at step 110: 0.9419
Accuracy at step 120: 0.9453
Accuracy at step 130: 0.9462
Accuracy at step 140: 0.9463
Accuracy at step 150: 0.9465
Accuracy at step 160: 0.9478
Accuracy at step 170: 0.9518
Accuracy at step 180: 0.9496
Accuracy at step 190: 0.9447
Adding run metadata for 199
Accuracy at step 200: 0.943
Accuracy at step 210: 0.9498
Accuracy at step 220: 0.9498
Accuracy at step 230: 0.9591
Accuracy at step 240: 0.9563
Accuracy at step 250: 0.9589
Accuracy at step 260: 0.9573
Accuracy at step 270: 0.9596
Accuracy at step 280: 0.9514
Accuracy at step 290: 0.9535
Adding run metadata for 299
Accuracy at step 300: 0.9543
Accuracy at step 310: 0.9626
Accuracy at step 320: 0.9651
Accuracy at step 330: 0.9658
Accuracy at step 340: 0.9607
Accuracy at step 350: 0.9609
Accuracy at step 360: 0.9562
Accuracy at step 370: 0.9593
Accuracy at step 380: 0.9646
Accuracy at step 390: 0.9638
Adding run metadata for 399
Accuracy at step 400: 0.9662
Accuracy at step 410: 0.9645
Accuracy at step 420: 0.9633
Accuracy at step 430: 0.966
Accuracy at step 440: 0.9635
Accuracy at step 450: 0.9657
Accuracy at step 460: 0.9606
Accuracy at step 470: 0.9603
Accuracy at step 480: 0.96
Accuracy at step 490: 0.9572
Adding run metadata for 499
Accuracy at step 500: 0.9686
Accuracy at step 510: 0.9626
Accuracy at step 520: 0.9575
Accuracy at step 530: 0.9639
Accuracy at step 540: 0.9623
Accuracy at step 550: 0.9607
Accuracy at step 560: 0.9653
Accuracy at step 570: 0.9616
Accuracy at step 580: 0.9623
Accuracy at step 590: 0.9615
Adding run metadata for 599
Accuracy at step 600: 0.9609
Accuracy at step 610: 0.9631
Accuracy at step 620: 0.9603
Accuracy at step 630: 0.9682
Accuracy at step 640: 0.9656
Accuracy at step 650: 0.9653
Accuracy at step 660: 0.9652
Accuracy at step 670: 0.9547
Accuracy at step 680: 0.9615
Accuracy at step 690: 0.9652
Adding run metadata for 699
Accuracy at step 700: 0.9626
Accuracy at step 710: 0.9691
Accuracy at step 720: 0.9662
Accuracy at step 730: 0.9675
Accuracy at step 740: 0.9664
Accuracy at step 750: 0.968
Accuracy at step 760: 0.9688
Accuracy at step 770: 0.9662
Accuracy at step 780: 0.966
Accuracy at step 790: 0.9681
Adding run metadata for 799
Accuracy at step 800: 0.9661
Accuracy at step 810: 0.9668
Accuracy at step 820: 0.9693
Accuracy at step 830: 0.9694
Accuracy at step 840: 0.9685
Accuracy at step 850: 0.9673
Accuracy at step 860: 0.9691
Accuracy at step 870: 0.9673
Accuracy at step 880: 0.9653
Accuracy at step 890: 0.9677
Adding run metadata for 899
Accuracy at step 900: 0.9652
Accuracy at step 910: 0.9656
Accuracy at step 920: 0.9677
Accuracy at step 930: 0.9676
Accuracy at step 940: 0.9666
Accuracy at step 950: 0.9656
Accuracy at step 960: 0.9678
Accuracy at step 970: 0.9707
Accuracy at step 980: 0.9688
Accuracy at step 990: 0.9663
Adding run metadata for 999

None
Delete TFJob
Delete the created TFJob and check that all created resources were removed as well.

client.delete_tfjob(name=TFJOB_NAME)
TFJob admin/mnist has been deleted
@retry(
    wait=wait_exponential(multiplier=2, min=1, max=10),
    stop=stop_after_attempt(30),
    reraise=True,
)
def assert_tfjob_removed(client, job_name):
    """Wait for TFJob be removed."""
    # fetch the existing TFJob names
    # verify that the Job was deleted successfully
    jobs = {job.metadata.name for job in client.list_tfjobs()}
    assert job_name not in jobs, f"Failed to delete TFJob {job_name}!"
# wait for TFJob resources to be removed successfully
assert_tfjob_removed(client, TFJOB_NAME)
Test PyTorchJob
Define a PyTorchJob
Define a PyTorchJob object before deploying it. This PyTorchJob is similar to [this](https://github.com/kubeflow/training-operator/blob/11b7a115e6538caeab405344af98f0d5b42a4c96/sdk/python/examples/kubeflow-pytorchjob-sdk.ipynb) example.

PYTORCHJOB_NAME = "pytorch-dist-mnist-gloo"
container = V1Container(
    name="pytorch",
    image="gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0",
    args=["--backend", "gloo"],
)

replica_spec = V1ReplicaSpec(
    replicas=1,
    restart_policy="OnFailure",
    template=V1PodTemplateSpec(
        metadata=V1ObjectMeta(annotations={"sidecar.istio.io/inject": "false"}),
        spec=V1PodSpec(containers=[container]),
    ),
)

pytorchjob = KubeflowOrgV1PyTorchJob(
    api_version="kubeflow.org/v1",
    kind="PyTorchJob",
    metadata=V1ObjectMeta(name=PYTORCHJOB_NAME),
    spec=KubeflowOrgV1PyTorchJobSpec(
        run_policy=V1RunPolicy(clean_pod_policy="None"),
        pytorch_replica_specs={"Master": replica_spec, "Worker": replica_spec},
    ),
)
Print the Job's info to verify it before submission.

print("Name:", pytorchjob.metadata.name)
print("Spec:", pytorchjob.spec.pytorch_replica_specs)
Name: pytorch-dist-mnist-gloo
Spec: {'Master': {'replicas': 1,
 'restart_policy': 'OnFailure',
 'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                           'creation_timestamp': None,
                           'deletion_grace_period_seconds': None,
                           'deletion_timestamp': None,
                           'finalizers': None,
                           'generate_name': None,
                           'generation': None,
                           'labels': None,
                           'managed_fields': None,
                           'name': None,
                           'namespace': None,
                           'owner_references': None,
                           'resource_version': None,
                           'self_link': None,
                           'uid': None},
              'spec': {'active_deadline_seconds': None,
                       'affinity': None,
                       'automount_service_account_token': None,
                       'containers': [{'args': ['--backend', 'gloo'],
                                       'command': None,
                                       'env': None,
                                       'env_from': None,
                                       'image': 'gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0',
                                       'image_pull_policy': None,
                                       'lifecycle': None,
                                       'liveness_probe': None,
                                       'name': 'pytorch',
                                       'ports': None,
                                       'readiness_probe': None,
                                       'resize_policy': None,
                                       'resources': None,
                                       'security_context': None,
                                       'startup_probe': None,
                                       'stdin': None,
                                       'stdin_once': None,
                                       'termination_message_path': None,
                                       'termination_message_policy': None,
                                       'tty': None,
                                       'volume_devices': None,
                                       'volume_mounts': None,
                                       'working_dir': None}],
                       'dns_config': None,
                       'dns_policy': None,
                       'enable_service_links': None,
                       'ephemeral_containers': None,
                       'host_aliases': None,
                       'host_ipc': None,
                       'host_network': None,
                       'host_pid': None,
                       'host_users': None,
                       'hostname': None,
                       'image_pull_secrets': None,
                       'init_containers': None,
                       'node_name': None,
                       'node_selector': None,
                       'os': None,
                       'overhead': None,
                       'preemption_policy': None,
                       'priority': None,
                       'priority_class_name': None,
                       'readiness_gates': None,
                       'resource_claims': None,
                       'restart_policy': None,
                       'runtime_class_name': None,
                       'scheduler_name': None,
                       'scheduling_gates': None,
                       'security_context': None,
                       'service_account': None,
                       'service_account_name': None,
                       'set_hostname_as_fqdn': None,
                       'share_process_namespace': None,
                       'subdomain': None,
                       'termination_grace_period_seconds': None,
                       'tolerations': None,
                       'topology_spread_constraints': None,
                       'volumes': None}}}, 'Worker': {'replicas': 1,
 'restart_policy': 'OnFailure',
 'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                           'creation_timestamp': None,
                           'deletion_grace_period_seconds': None,
                           'deletion_timestamp': None,
                           'finalizers': None,
                           'generate_name': None,
                           'generation': None,
                           'labels': None,
                           'managed_fields': None,
                           'name': None,
                           'namespace': None,
                           'owner_references': None,
                           'resource_version': None,
                           'self_link': None,
                           'uid': None},
              'spec': {'active_deadline_seconds': None,
                       'affinity': None,
                       'automount_service_account_token': None,
                       'containers': [{'args': ['--backend', 'gloo'],
                                       'command': None,
                                       'env': None,
                                       'env_from': None,
                                       'image': 'gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0',
                                       'image_pull_policy': None,
                                       'lifecycle': None,
                                       'liveness_probe': None,
                                       'name': 'pytorch',
                                       'ports': None,
                                       'readiness_probe': None,
                                       'resize_policy': None,
                                       'resources': None,
                                       'security_context': None,
                                       'startup_probe': None,
                                       'stdin': None,
                                       'stdin_once': None,
                                       'termination_message_path': None,
                                       'termination_message_policy': None,
                                       'tty': None,
                                       'volume_devices': None,
                                       'volume_mounts': None,
                                       'working_dir': None}],
                       'dns_config': None,
                       'dns_policy': None,
                       'enable_service_links': None,
                       'ephemeral_containers': None,
                       'host_aliases': None,
                       'host_ipc': None,
                       'host_network': None,
                       'host_pid': None,
                       'host_users': None,
                       'hostname': None,
                       'image_pull_secrets': None,
                       'init_containers': None,
                       'node_name': None,
                       'node_selector': None,
                       'os': None,
                       'overhead': None,
                       'preemption_policy': None,
                       'priority': None,
                       'priority_class_name': None,
                       'readiness_gates': None,
                       'resource_claims': None,
                       'restart_policy': None,
                       'runtime_class_name': None,
                       'scheduler_name': None,
                       'scheduling_gates': None,
                       'security_context': None,
                       'service_account': None,
                       'service_account_name': None,
                       'set_hostname_as_fqdn': None,
                       'share_process_namespace': None,
                       'subdomain': None,
                       'termination_grace_period_seconds': None,
                       'tolerations': None,
                       'topology_spread_constraints': None,
                       'volumes': None}}}}
List existing PyTorchJob
List PyTorchJob in the current namespace.

[job.metadata.name for job in client.list_pytorchjobs()]
[]
Create PyTorchJob
Create a PyTorchJob using the SDK.

client.create_pytorchjob(pytorchjob)
PyTorchJob admin/pytorch-dist-mnist-gloo has been created
Get PyTorchJob
Get the created PyTorchJob by name and check its data.
Make sure that it completes successfully before proceeding.

# verify that the Job was created successfully
# raises an error if it doesn't exist
client.get_pytorchjob(name=PYTORCHJOB_NAME);
# wait for the Job to complete successfully
assert_job_succeeded(client, PYTORCHJOB_NAME, job_kind="PyTorchJob")
job = client.get_pytorchjob(name=PYTORCHJOB_NAME)
print("Job:", job.metadata.name, end="\n\n")
print("Job Spec:", job.spec, sep="\n", end="\n\n")
print("Job Status:", job.status, sep="\n", end="\n\n")
Job: pytorch-dist-mnist-gloo

Job Spec:
{'elastic_policy': None,
 'pytorch_replica_specs': {'Master': {'replicas': 1,
                                      'restart_policy': 'OnFailure',
                                      'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                                                                'creation_timestamp': None,
                                                                'deletion_grace_period_seconds': None,
                                                                'deletion_timestamp': None,
                                                                'finalizers': None,
                                                                'generate_name': None,
                                                                'generation': None,
                                                                'labels': None,
                                                                'managed_fields': None,
                                                                'name': None,
                                                                'namespace': None,
                                                                'owner_references': None,
                                                                'resource_version': None,
                                                                'self_link': None,
                                                                'uid': None},
                                                   'spec': {'active_deadline_seconds': None,
                                                            'affinity': None,
                                                            'automount_service_account_token': None,
                                                            'containers': [{'args': ['--backend',
                                                                                     'gloo'],
                                                                            'command': None,
                                                                            'env': None,
                                                                            'env_from': None,
                                                                            'image': 'gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0',
                                                                            'image_pull_policy': None,
                                                                            'lifecycle': None,
                                                                            'liveness_probe': None,
                                                                            'name': 'pytorch',
                                                                            'ports': None,
                                                                            'readiness_probe': None,
                                                                            'resize_policy': None,
                                                                            'resources': None,
                                                                            'security_context': None,
                                                                            'startup_probe': None,
                                                                            'stdin': None,
                                                                            'stdin_once': None,
                                                                            'termination_message_path': None,
                                                                            'termination_message_policy': None,
                                                                            'tty': None,
                                                                            'volume_devices': None,
                                                                            'volume_mounts': None,
                                                                            'working_dir': None}],
                                                            'dns_config': None,
                                                            'dns_policy': None,
                                                            'enable_service_links': None,
                                                            'ephemeral_containers': None,
                                                            'host_aliases': None,
                                                            'host_ipc': None,
                                                            'host_network': None,
                                                            'host_pid': None,
                                                            'host_users': None,
                                                            'hostname': None,
                                                            'image_pull_secrets': None,
                                                            'init_containers': None,
                                                            'node_name': None,
                                                            'node_selector': None,
                                                            'os': None,
                                                            'overhead': None,
                                                            'preemption_policy': None,
                                                            'priority': None,
                                                            'priority_class_name': None,
                                                            'readiness_gates': None,
                                                            'resource_claims': None,
                                                            'restart_policy': None,
                                                            'runtime_class_name': None,
                                                            'scheduler_name': None,
                                                            'scheduling_gates': None,
                                                            'security_context': None,
                                                            'service_account': None,
                                                            'service_account_name': None,
                                                            'set_hostname_as_fqdn': None,
                                                            'share_process_namespace': None,
                                                            'subdomain': None,
                                                            'termination_grace_period_seconds': None,
                                                            'tolerations': None,
                                                            'topology_spread_constraints': None,
                                                            'volumes': None}}},
                           'Worker': {'replicas': 1,
                                      'restart_policy': 'OnFailure',
                                      'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                                                                'creation_timestamp': None,
                                                                'deletion_grace_period_seconds': None,
                                                                'deletion_timestamp': None,
                                                                'finalizers': None,
                                                                'generate_name': None,
                                                                'generation': None,
                                                                'labels': None,
                                                                'managed_fields': None,
                                                                'name': None,
                                                                'namespace': None,
                                                                'owner_references': None,
                                                                'resource_version': None,
                                                                'self_link': None,
                                                                'uid': None},
                                                   'spec': {'active_deadline_seconds': None,
                                                            'affinity': None,
                                                            'automount_service_account_token': None,
                                                            'containers': [{'args': ['--backend',
                                                                                     'gloo'],
                                                                            'command': None,
                                                                            'env': None,
                                                                            'env_from': None,
                                                                            'image': 'gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0',
                                                                            'image_pull_policy': None,
                                                                            'lifecycle': None,
                                                                            'liveness_probe': None,
                                                                            'name': 'pytorch',
                                                                            'ports': None,
                                                                            'readiness_probe': None,
                                                                            'resize_policy': None,
                                                                            'resources': None,
                                                                            'security_context': None,
                                                                            'startup_probe': None,
                                                                            'stdin': None,
                                                                            'stdin_once': None,
                                                                            'termination_message_path': None,
                                                                            'termination_message_policy': None,
                                                                            'tty': None,
                                                                            'volume_devices': None,
                                                                            'volume_mounts': None,
                                                                            'working_dir': None}],
                                                            'dns_config': None,
                                                            'dns_policy': None,
                                                            'enable_service_links': None,
                                                            'ephemeral_containers': None,
                                                            'host_aliases': None,
                                                            'host_ipc': None,
                                                            'host_network': None,
                                                            'host_pid': None,
                                                            'host_users': None,
                                                            'hostname': None,
                                                            'image_pull_secrets': None,
                                                            'init_containers': None,
                                                            'node_name': None,
                                                            'node_selector': None,
                                                            'os': None,
                                                            'overhead': None,
                                                            'preemption_policy': None,
                                                            'priority': None,
                                                            'priority_class_name': None,
                                                            'readiness_gates': None,
                                                            'resource_claims': None,
                                                            'restart_policy': None,
                                                            'runtime_class_name': None,
                                                            'scheduler_name': None,
                                                            'scheduling_gates': None,
                                                            'security_context': None,
                                                            'service_account': None,
                                                            'service_account_name': None,
                                                            'set_hostname_as_fqdn': None,
                                                            'share_process_namespace': None,
                                                            'subdomain': None,
                                                            'termination_grace_period_seconds': None,
                                                            'tolerations': None,
                                                            'topology_spread_constraints': None,
                                                            'volumes': None}}}},
 'run_policy': {'active_deadline_seconds': None,
                'backoff_limit': None,
                'clean_pod_policy': 'None',
                'scheduling_policy': None,
                'ttl_seconds_after_finished': None}}

Job Status:
{'completion_time': datetime.datetime(2023, 8, 23, 15, 2, 39, tzinfo=tzlocal()),
 'conditions': [{'last_transition_time': datetime.datetime(2023, 8, 23, 14, 53, 3, tzinfo=tzlocal()),
                 'last_update_time': datetime.datetime(2023, 8, 23, 14, 53, 3, tzinfo=tzlocal()),
                 'message': 'PyTorchJob pytorch-dist-mnist-gloo is created.',
                 'reason': 'PyTorchJobCreated',
                 'status': 'True',
                 'type': 'Created'},
                {'last_transition_time': datetime.datetime(2023, 8, 23, 14, 53, 7, tzinfo=tzlocal()),
                 'last_update_time': datetime.datetime(2023, 8, 23, 14, 53, 7, tzinfo=tzlocal()),
                 'message': 'PyTorchJob pytorch-dist-mnist-gloo is running.',
                 'reason': 'JobRunning',
                 'status': 'False',
                 'type': 'Running'},
                {'last_transition_time': datetime.datetime(2023, 8, 23, 15, 2, 39, tzinfo=tzlocal()),
                 'last_update_time': datetime.datetime(2023, 8, 23, 15, 2, 39, tzinfo=tzlocal()),
                 'message': 'PyTorchJob pytorch-dist-mnist-gloo is '
                            'successfully completed.',
                 'reason': 'JobSucceeded',
                 'status': 'True',
                 'type': 'Succeeded'}],
 'last_reconcile_time': None,
 'replica_statuses': {'Master': {'active': None,
                                 'failed': None,
                                 'label_selector': None,
                                 'selector': 'training.kubeflow.org/job-name=pytorch-dist-mnist-gloo,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=master',
                                 'succeeded': 1},
                      'Worker': {'active': None,
                                 'failed': None,
                                 'label_selector': None,
                                 'selector': 'training.kubeflow.org/job-name=pytorch-dist-mnist-gloo,training.kubeflow.org/operator-name=pytorchjob-controller,training.kubeflow.org/replica-type=worker',
                                 'succeeded': 1}},
 'start_time': datetime.datetime(2023, 8, 23, 14, 53, 6, tzinfo=tzlocal())}

Get PyTorchJob Training logs
Get and print the training logs of the PyTorchJob with the training steps

print_training_logs(client, PYTORCHJOB_NAME, container="pytorch")
The logs of pod pytorch-dist-mnist-gloo-master-0:
 Using distributed PyTorch with gloo backend
Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz
Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz
Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz
Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
Processing...
Done!
Train Epoch: 1 [0/60000 (0%)]	loss=2.3000
Train Epoch: 1 [640/60000 (1%)]	loss=2.2135
Train Epoch: 1 [1280/60000 (2%)]	loss=2.1704
Train Epoch: 1 [1920/60000 (3%)]	loss=2.0766
Train Epoch: 1 [2560/60000 (4%)]	loss=1.8682
Train Epoch: 1 [3200/60000 (5%)]	loss=1.4137
Train Epoch: 1 [3840/60000 (6%)]	loss=1.0007
Train Epoch: 1 [4480/60000 (7%)]	loss=0.7769
Train Epoch: 1 [5120/60000 (9%)]	loss=0.4595
Train Epoch: 1 [5760/60000 (10%)]	loss=0.4859
Train Epoch: 1 [6400/60000 (11%)]	loss=0.4388
Train Epoch: 1 [7040/60000 (12%)]	loss=0.4100
Train Epoch: 1 [7680/60000 (13%)]	loss=0.4610
Train Epoch: 1 [8320/60000 (14%)]	loss=0.4282
Train Epoch: 1 [8960/60000 (15%)]	loss=0.3998
Train Epoch: 1 [9600/60000 (16%)]	loss=0.3873
Train Epoch: 1 [10240/60000 (17%)]	loss=0.2990
Train Epoch: 1 [10880/60000 (18%)]	loss=0.5038
Train Epoch: 1 [11520/60000 (19%)]	loss=0.5224
Train Epoch: 1 [12160/60000 (20%)]	loss=0.3384
Train Epoch: 1 [12800/60000 (21%)]	loss=0.3656
Train Epoch: 1 [13440/60000 (22%)]	loss=0.4493
Train Epoch: 1 [14080/60000 (23%)]	loss=0.3045
Train Epoch: 1 [14720/60000 (25%)]	loss=0.3579
Train Epoch: 1 [15360/60000 (26%)]	loss=0.3287
Train Epoch: 1 [16000/60000 (27%)]	loss=0.4379
Train Epoch: 1 [16640/60000 (28%)]	loss=0.3642
Train Epoch: 1 [17280/60000 (29%)]	loss=0.3155
Train Epoch: 1 [17920/60000 (30%)]	loss=0.2017
Train Epoch: 1 [18560/60000 (31%)]	loss=0.4993
Train Epoch: 1 [19200/60000 (32%)]	loss=0.3273
Train Epoch: 1 [19840/60000 (33%)]	loss=0.1190
Train Epoch: 1 [20480/60000 (34%)]	loss=0.1905
Train Epoch: 1 [21120/60000 (35%)]	loss=0.1402
Train Epoch: 1 [21760/60000 (36%)]	loss=0.3142
Train Epoch: 1 [22400/60000 (37%)]	loss=0.1494
Train Epoch: 1 [23040/60000 (38%)]	loss=0.2903
Train Epoch: 1 [23680/60000 (39%)]	loss=0.4697
Train Epoch: 1 [24320/60000 (41%)]	loss=0.2150
Train Epoch: 1 [24960/60000 (42%)]	loss=0.1531
Train Epoch: 1 [25600/60000 (43%)]	loss=0.2251
Train Epoch: 1 [26240/60000 (44%)]	loss=0.2623
Train Epoch: 1 [26880/60000 (45%)]	loss=0.2328
Train Epoch: 1 [27520/60000 (46%)]	loss=0.2624
Train Epoch: 1 [28160/60000 (47%)]	loss=0.2117
Train Epoch: 1 [28800/60000 (48%)]	loss=0.1329
Train Epoch: 1 [29440/60000 (49%)]	loss=0.2769
Train Epoch: 1 [30080/60000 (50%)]	loss=0.0949
Train Epoch: 1 [30720/60000 (51%)]	loss=0.1286
Train Epoch: 1 [31360/60000 (52%)]	loss=0.2456
Train Epoch: 1 [32000/60000 (53%)]	loss=0.3398
Train Epoch: 1 [32640/60000 (54%)]	loss=0.1523
Train Epoch: 1 [33280/60000 (55%)]	loss=0.0907
Train Epoch: 1 [33920/60000 (57%)]	loss=0.1444
Train Epoch: 1 [34560/60000 (58%)]	loss=0.1973
Train Epoch: 1 [35200/60000 (59%)]	loss=0.2179
Train Epoch: 1 [35840/60000 (60%)]	loss=0.0631
Train Epoch: 1 [36480/60000 (61%)]	loss=0.1361
Train Epoch: 1 [37120/60000 (62%)]	loss=0.1153
Train Epoch: 1 [37760/60000 (63%)]	loss=0.2371
Train Epoch: 1 [38400/60000 (64%)]	loss=0.0646
Train Epoch: 1 [39040/60000 (65%)]	loss=0.1058
Train Epoch: 1 [39680/60000 (66%)]	loss=0.1605
Train Epoch: 1 [40320/60000 (67%)]	loss=0.1091
Train Epoch: 1 [40960/60000 (68%)]	loss=0.1778
Train Epoch: 1 [41600/60000 (69%)]	loss=0.2305
Train Epoch: 1 [42240/60000 (70%)]	loss=0.0736
Train Epoch: 1 [42880/60000 (71%)]	loss=0.1553
Train Epoch: 1 [43520/60000 (72%)]	loss=0.2750
Train Epoch: 1 [44160/60000 (74%)]	loss=0.1419
Train Epoch: 1 [44800/60000 (75%)]	loss=0.1165
Train Epoch: 1 [45440/60000 (76%)]	loss=0.1220
Train Epoch: 1 [46080/60000 (77%)]	loss=0.0775
Train Epoch: 1 [46720/60000 (78%)]	loss=0.1951
Train Epoch: 1 [47360/60000 (79%)]	loss=0.0710
Train Epoch: 1 [48000/60000 (80%)]	loss=0.2097
Train Epoch: 1 [48640/60000 (81%)]	loss=0.1375
Train Epoch: 1 [49280/60000 (82%)]	loss=0.0933
Train Epoch: 1 [49920/60000 (83%)]	loss=0.1088
Train Epoch: 1 [50560/60000 (84%)]	loss=0.1188
Train Epoch: 1 [51200/60000 (85%)]	loss=0.1451
Train Epoch: 1 [51840/60000 (86%)]	loss=0.0678
Train Epoch: 1 [52480/60000 (87%)]	loss=0.0242
Train Epoch: 1 [53120/60000 (88%)]	loss=0.2604
Train Epoch: 1 [53760/60000 (90%)]	loss=0.0919
Train Epoch: 1 [54400/60000 (91%)]	loss=0.1287
Train Epoch: 1 [55040/60000 (92%)]	loss=0.1906
Train Epoch: 1 [55680/60000 (93%)]	loss=0.0345
Train Epoch: 1 [56320/60000 (94%)]	loss=0.0359
Train Epoch: 1 [56960/60000 (95%)]	loss=0.0769
Train Epoch: 1 [57600/60000 (96%)]	loss=0.1165
Train Epoch: 1 [58240/60000 (97%)]	loss=0.1932
Train Epoch: 1 [58880/60000 (98%)]	loss=0.2059
Train Epoch: 1 [59520/60000 (99%)]	loss=0.0629

accuracy=0.9664


None
Delete PyTorchJob
Delete the created PyTorchJob and check that all created resources were removed as well.

client.delete_pytorchjob(name=PYTORCHJOB_NAME)
PyTorchJob admin/pytorch-dist-mnist-gloo has been deleted
@retry(
    wait=wait_exponential(multiplier=2, min=1, max=10),
    stop=stop_after_attempt(30),
    reraise=True,
)
def assert_pytorchjob_removed(client, job_name):
    """Wait for PyTorchJob be removed."""
    # fetch the existing PyTorchJob names
    # verify that the Job was deleted successfully
    jobs = {job.metadata.name for job in client.list_pytorchjobs()}
    assert job_name not in jobs, f"Failed to delete PyTorchJob {job_name}!"
# wait for PyTorch job to be removed successfully
assert_pytorchjob_removed(client, PYTORCHJOB_NAME)
Test PaddlePaddle
Define a PaddleJob
Define a PaddleJob object before deploying it. This PaddleJob is using [this](https://github.com/kubeflow/training-operator/blob/11b7a115e6538caeab405344af98f0d5b42a4c96/examples/paddlepaddle/simple-cpu.yaml) example.

PADDLEJOB_NAME = "paddle-simple-cpu"
port = V1ContainerPort(container_port=37777, name="master")

container = V1Container(
    name="paddle",
    image="registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-cpu",
    command=["python"],
    args=["-m", "paddle.distributed.launch", "run_check"],
    ports=[port],
)

replica_spec = V1ReplicaSpec(
    replicas=2,
    restart_policy="OnFailure",
    template=V1PodTemplateSpec(
        metadata=V1ObjectMeta(annotations={"sidecar.istio.io/inject": "false"}),
        spec=V1PodSpec(containers=[container]),
    ),
)

paddlejob = KubeflowOrgV1PaddleJob(
    api_version="kubeflow.org/v1",
    kind="PaddleJob",
    metadata=V1ObjectMeta(name=PADDLEJOB_NAME),
    spec=KubeflowOrgV1PaddleJobSpec(
        run_policy=V1RunPolicy(clean_pod_policy="None"),
        paddle_replica_specs={"Worker": replica_spec},
    ),
)
Print the Job's info to verify it before submission.

print("Name:", paddlejob.metadata.name)
print("Spec:", paddlejob.spec.paddle_replica_specs)
Name: paddle-simple-cpu
Spec: {'Worker': {'replicas': 2,
 'restart_policy': 'OnFailure',
 'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                           'creation_timestamp': None,
                           'deletion_grace_period_seconds': None,
                           'deletion_timestamp': None,
                           'finalizers': None,
                           'generate_name': None,
                           'generation': None,
                           'labels': None,
                           'managed_fields': None,
                           'name': None,
                           'namespace': None,
                           'owner_references': None,
                           'resource_version': None,
                           'self_link': None,
                           'uid': None},
              'spec': {'active_deadline_seconds': None,
                       'affinity': None,
                       'automount_service_account_token': None,
                       'containers': [{'args': ['-m',
                                                'paddle.distributed.launch',
                                                'run_check'],
                                       'command': ['python'],
                                       'env': None,
                                       'env_from': None,
                                       'image': 'registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-cpu',
                                       'image_pull_policy': None,
                                       'lifecycle': None,
                                       'liveness_probe': None,
                                       'name': 'paddle',
                                       'ports': [{'container_port': 37777,
                                                  'host_ip': None,
                                                  'host_port': None,
                                                  'name': 'master',
                                                  'protocol': None}],
                                       'readiness_probe': None,
                                       'resize_policy': None,
                                       'resources': None,
                                       'security_context': None,
                                       'startup_probe': None,
                                       'stdin': None,
                                       'stdin_once': None,
                                       'termination_message_path': None,
                                       'termination_message_policy': None,
                                       'tty': None,
                                       'volume_devices': None,
                                       'volume_mounts': None,
                                       'working_dir': None}],
                       'dns_config': None,
                       'dns_policy': None,
                       'enable_service_links': None,
                       'ephemeral_containers': None,
                       'host_aliases': None,
                       'host_ipc': None,
                       'host_network': None,
                       'host_pid': None,
                       'host_users': None,
                       'hostname': None,
                       'image_pull_secrets': None,
                       'init_containers': None,
                       'node_name': None,
                       'node_selector': None,
                       'os': None,
                       'overhead': None,
                       'preemption_policy': None,
                       'priority': None,
                       'priority_class_name': None,
                       'readiness_gates': None,
                       'resource_claims': None,
                       'restart_policy': None,
                       'runtime_class_name': None,
                       'scheduler_name': None,
                       'scheduling_gates': None,
                       'security_context': None,
                       'service_account': None,
                       'service_account_name': None,
                       'set_hostname_as_fqdn': None,
                       'share_process_namespace': None,
                       'subdomain': None,
                       'termination_grace_period_seconds': None,
                       'tolerations': None,
                       'topology_spread_constraints': None,
                       'volumes': None}}}}
List existing PaddleJobs
List PaddleJobs in the current namespace.

[job.metadata.name for job in client.list_paddlejobs()]
[]
Create PaddleJob
Create a PaddleJob using the SDK.

client.create_paddlejob(paddlejob)
PaddleJob admin/paddle-simple-cpu has been created
Get PaddleJob
Get the created PaddleJob by name and check its data.
Make sure that it completes successfully before proceeding.

# verify that the Job was created successfully
# raises an error if it doesn't exist
client.get_paddlejob(name=PADDLEJOB_NAME)
{'api_version': 'kubeflow.org/v1',
 'kind': 'PaddleJob',
 'metadata': {'annotations': None,
              'creation_timestamp': datetime.datetime(2023, 8, 23, 15, 3, 5, tzinfo=tzlocal()),
              'deletion_grace_period_seconds': None,
              'deletion_timestamp': None,
              'finalizers': None,
              'generate_name': None,
              'generation': 1,
              'labels': None,
              'managed_fields': [{'api_version': 'kubeflow.org/v1',
                                  'fields_type': 'FieldsV1',
                                  'fields_v1': {'f:spec': {'.': {},
                                                           'f:paddleReplicaSpecs': {'.': {},
                                                                                    'f:Worker': {'.': {},
                                                                                                 'f:replicas': {},
                                                                                                 'f:restartPolicy': {},
                                                                                                 'f:template': {'.': {},
                                                                                                                'f:metadata': {'.': {},
                                                                                                                               'f:annotations': {'.': {},
                                                                                                                                                 'f:sidecar.istio.io/inject': {}}},
                                                                                                                'f:spec': {'.': {},
                                                                                                                           'f:containers': {}}}}},
                                                           'f:runPolicy': {'.': {},
                                                                           'f:cleanPodPolicy': {}}}},
                                  'manager': 'OpenAPI-Generator',
                                  'operation': 'Update',
                                  'subresource': None,
                                  'time': datetime.datetime(2023, 8, 23, 15, 3, 5, tzinfo=tzlocal())}],
              'name': 'paddle-simple-cpu',
              'namespace': 'admin',
              'owner_references': None,
              'resource_version': '944796',
              'self_link': None,
              'uid': 'b1c715bf-5d24-4e17-a8d2-a2edfcc2683a'},
 'spec': {'elastic_policy': None,
          'paddle_replica_specs': {'Worker': {'replicas': 2,
                                              'restart_policy': 'OnFailure',
                                              'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                                                                        'creation_timestamp': None,
                                                                        'deletion_grace_period_seconds': None,
                                                                        'deletion_timestamp': None,
                                                                        'finalizers': None,
                                                                        'generate_name': None,
                                                                        'generation': None,
                                                                        'labels': None,
                                                                        'managed_fields': None,
                                                                        'name': None,
                                                                        'namespace': None,
                                                                        'owner_references': None,
                                                                        'resource_version': None,
                                                                        'self_link': None,
                                                                        'uid': None},
                                                           'spec': {'active_deadline_seconds': None,
                                                                    'affinity': None,
                                                                    'automount_service_account_token': None,
                                                                    'containers': [{'args': ['-m',
                                                                                             'paddle.distributed.launch',
                                                                                             'run_check'],
                                                                                    'command': ['python'],
                                                                                    'env': None,
                                                                                    'env_from': None,
                                                                                    'image': 'registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-cpu',
                                                                                    'image_pull_policy': None,
                                                                                    'lifecycle': None,
                                                                                    'liveness_probe': None,
                                                                                    'name': 'paddle',
                                                                                    'ports': [{'container_port': 37777,
                                                                                               'host_ip': None,
                                                                                               'host_port': None,
                                                                                               'name': 'master',
                                                                                               'protocol': 'TCP'}],
                                                                                    'readiness_probe': None,
                                                                                    'resize_policy': None,
                                                                                    'resources': None,
                                                                                    'security_context': None,
                                                                                    'startup_probe': None,
                                                                                    'stdin': None,
                                                                                    'stdin_once': None,
                                                                                    'termination_message_path': None,
                                                                                    'termination_message_policy': None,
                                                                                    'tty': None,
                                                                                    'volume_devices': None,
                                                                                    'volume_mounts': None,
                                                                                    'working_dir': None}],
                                                                    'dns_config': None,
                                                                    'dns_policy': None,
                                                                    'enable_service_links': None,
                                                                    'ephemeral_containers': None,
                                                                    'host_aliases': None,
                                                                    'host_ipc': None,
                                                                    'host_network': None,
                                                                    'host_pid': None,
                                                                    'host_users': None,
                                                                    'hostname': None,
                                                                    'image_pull_secrets': None,
                                                                    'init_containers': None,
                                                                    'node_name': None,
                                                                    'node_selector': None,
                                                                    'os': None,
                                                                    'overhead': None,
                                                                    'preemption_policy': None,
                                                                    'priority': None,
                                                                    'priority_class_name': None,
                                                                    'readiness_gates': None,
                                                                    'resource_claims': None,
                                                                    'restart_policy': None,
                                                                    'runtime_class_name': None,
                                                                    'scheduler_name': None,
                                                                    'scheduling_gates': None,
                                                                    'security_context': None,
                                                                    'service_account': None,
                                                                    'service_account_name': None,
                                                                    'set_hostname_as_fqdn': None,
                                                                    'share_process_namespace': None,
                                                                    'subdomain': None,
                                                                    'termination_grace_period_seconds': None,
                                                                    'tolerations': None,
                                                                    'topology_spread_constraints': None,
                                                                    'volumes': None}}}},
          'run_policy': {'active_deadline_seconds': None,
                         'backoff_limit': None,
                         'clean_pod_policy': 'None',
                         'scheduling_policy': None,
                         'ttl_seconds_after_finished': None}},
 'status': None}
# wait for the Job to complete successfully
assert_job_succeeded(client, PADDLEJOB_NAME, job_kind="PaddleJob")
job = client.get_paddlejob(name=PADDLEJOB_NAME)
print("Job:", job.metadata.name, end="\n\n")
print("Job Spec:", job.spec, sep="\n", end="\n\n")
print("Job Status:", job.status, sep="\n", end="\n\n")
Job: paddle-simple-cpu

Job Spec:
{'elastic_policy': None,
 'paddle_replica_specs': {'Worker': {'replicas': 2,
                                     'restart_policy': 'OnFailure',
                                     'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},
                                                               'creation_timestamp': None,
                                                               'deletion_grace_period_seconds': None,
                                                               'deletion_timestamp': None,
                                                               'finalizers': None,
                                                               'generate_name': None,
                                                               'generation': None,
                                                               'labels': None,
                                                               'managed_fields': None,
                                                               'name': None,
                                                               'namespace': None,
                                                               'owner_references': None,
                                                               'resource_version': None,
                                                               'self_link': None,
                                                               'uid': None},
                                                  'spec': {'active_deadline_seconds': None,
                                                           'affinity': None,
                                                           'automount_service_account_token': None,
                                                           'containers': [{'args': ['-m',
                                                                                    'paddle.distributed.launch',
                                                                                    'run_check'],
                                                                           'command': ['python'],
                                                                           'env': None,
                                                                           'env_from': None,
                                                                           'image': 'registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-cpu',
                                                                           'image_pull_policy': None,
                                                                           'lifecycle': None,
                                                                           'liveness_probe': None,
                                                                           'name': 'paddle',
                                                                           'ports': [{'container_port': 37777,
                                                                                      'host_ip': None,
                                                                                      'host_port': None,
                                                                                      'name': 'master',
                                                                                      'protocol': 'TCP'}],
                                                                           'readiness_probe': None,
                                                                           'resize_policy': None,
                                                                           'resources': None,
                                                                           'security_context': None,
                                                                           'startup_probe': None,
                                                                           'stdin': None,
                                                                           'stdin_once': None,
                                                                           'termination_message_path': None,
                                                                           'termination_message_policy': None,
                                                                           'tty': None,
                                                                           'volume_devices': None,
                                                                           'volume_mounts': None,
                                                                           'working_dir': None}],
                                                           'dns_config': None,
                                                           'dns_policy': None,
                                                           'enable_service_links': None,
                                                           'ephemeral_containers': None,
                                                           'host_aliases': None,
                                                           'host_ipc': None,
                                                           'host_network': None,
                                                           'host_pid': None,
                                                           'host_users': None,
                                                           'hostname': None,
                                                           'image_pull_secrets': None,
                                                           'init_containers': None,
                                                           'node_name': None,
                                                           'node_selector': None,
                                                           'os': None,
                                                           'overhead': None,
                                                           'preemption_policy': None,
                                                           'priority': None,
                                                           'priority_class_name': None,
                                                           'readiness_gates': None,
                                                           'resource_claims': None,
                                                           'restart_policy': None,
                                                           'runtime_class_name': None,
                                                           'scheduler_name': None,
                                                           'scheduling_gates': None,
                                                           'security_context': None,
                                                           'service_account': None,
                                                           'service_account_name': None,
                                                           'set_hostname_as_fqdn': None,
                                                           'share_process_namespace': None,
                                                           'subdomain': None,
                                                           'termination_grace_period_seconds': None,
                                                           'tolerations': None,
                                                           'topology_spread_constraints': None,
                                                           'volumes': None}}}},
 'run_policy': {'active_deadline_seconds': None,
                'backoff_limit': None,
                'clean_pod_policy': 'None',
                'scheduling_policy': None,
                'ttl_seconds_after_finished': None}}

Job Status:
{'completion_time': datetime.datetime(2023, 8, 23, 15, 3, 24, tzinfo=tzlocal()),
 'conditions': [{'last_transition_time': datetime.datetime(2023, 8, 23, 15, 3, 5, tzinfo=tzlocal()),
                 'last_update_time': datetime.datetime(2023, 8, 23, 15, 3, 5, tzinfo=tzlocal()),
                 'message': 'PaddleJob paddle-simple-cpu is created.',
                 'reason': 'PaddleJobCreated',
                 'status': 'True',
                 'type': 'Created'},
                {'last_transition_time': datetime.datetime(2023, 8, 23, 15, 3, 8, tzinfo=tzlocal()),
                 'last_update_time': datetime.datetime(2023, 8, 23, 15, 3, 8, tzinfo=tzlocal()),
                 'message': 'PaddleJob admin/paddle-simple-cpu is running.',
                 'reason': 'JobRunning',
                 'status': 'False',
                 'type': 'Running'},
                {'last_transition_time': datetime.datetime(2023, 8, 23, 15, 3, 24, tzinfo=tzlocal()),
                 'last_update_time': datetime.datetime(2023, 8, 23, 15, 3, 24, tzinfo=tzlocal()),
                 'message': 'PaddleJob admin/paddle-simple-cpu successfully '
                            'completed.',
                 'reason': 'JobSucceeded',
                 'status': 'True',
                 'type': 'Succeeded'}],
 'last_reconcile_time': None,
 'replica_statuses': {'Worker': {'active': None,
                                 'failed': None,
                                 'label_selector': None,
                                 'selector': 'training.kubeflow.org/job-name=paddle-simple-cpu,training.kubeflow.org/operator-name=paddlejob-controller,training.kubeflow.org/replica-type=worker',
                                 'succeeded': 2}},
 'start_time': datetime.datetime(2023, 8, 23, 15, 3, 8, tzinfo=tzlocal())}

Get PaddleJob Training logs
Get and print the training logs of the PaddleJob with the training steps

print_training_logs(client, PADDLEJOB_NAME, container="paddle", is_master=False)
The logs of pod paddle-simple-cpu-worker-1:
 LAUNCH INFO 2023-08-23 15:03:11,720 Paddle Distributed Test begin...
LAUNCH INFO 2023-08-23 15:03:11,729 -----------  Configuration  ----------------------
LAUNCH INFO 2023-08-23 15:03:11,729 devices: None
LAUNCH INFO 2023-08-23 15:03:11,729 elastic_level: -1
LAUNCH INFO 2023-08-23 15:03:11,729 elastic_timeout: 30
LAUNCH INFO 2023-08-23 15:03:11,729 gloo_port: 6767
LAUNCH INFO 2023-08-23 15:03:11,729 host: None
LAUNCH INFO 2023-08-23 15:03:11,729 ips: None
LAUNCH INFO 2023-08-23 15:03:11,729 job_id: paddle-simple-cpu
LAUNCH INFO 2023-08-23 15:03:11,729 legacy: False
LAUNCH INFO 2023-08-23 15:03:11,729 log_dir: log
LAUNCH INFO 2023-08-23 15:03:11,729 log_level: INFO
LAUNCH INFO 2023-08-23 15:03:11,729 master: paddle-simple-cpu-worker-0:37777
LAUNCH INFO 2023-08-23 15:03:11,729 max_restart: 3
LAUNCH INFO 2023-08-23 15:03:11,729 nnodes: 2
LAUNCH INFO 2023-08-23 15:03:11,729 nproc_per_node: None
LAUNCH INFO 2023-08-23 15:03:11,729 rank: -1
LAUNCH INFO 2023-08-23 15:03:11,729 run_mode: collective
LAUNCH INFO 2023-08-23 15:03:11,729 server_num: None
LAUNCH INFO 2023-08-23 15:03:11,730 servers: 
LAUNCH INFO 2023-08-23 15:03:11,730 start_port: 6070
LAUNCH INFO 2023-08-23 15:03:11,730 trainer_num: None
LAUNCH INFO 2023-08-23 15:03:11,730 trainers: 
LAUNCH INFO 2023-08-23 15:03:11,730 training_script: /usr/local/lib/python3.7/dist-packages/paddle/distributed/launch/plugins/test.py
LAUNCH INFO 2023-08-23 15:03:11,730 training_script_args: []
LAUNCH INFO 2023-08-23 15:03:11,730 with_gloo: 1
LAUNCH INFO 2023-08-23 15:03:11,730 --------------------------------------------------
LAUNCH INFO 2023-08-23 15:03:11,730 Job: paddle-simple-cpu, mode collective, replicas 2[2:2], elastic False
LAUNCH INFO 2023-08-23 15:03:11,730 Waiting peer start...
LAUNCH INFO 2023-08-23 15:03:11,869 Run Pod: ewzhfo, replicas 1, status ready
LAUNCH INFO 2023-08-23 15:03:11,929 Watching Pod: ewzhfo, replicas 1, status running
LAUNCH INFO 2023-08-23 15:03:20,938 Pod completed
LAUNCH INFO 2023-08-23 15:03:20,938 Exit code 0
LAUNCH WARNNING args master is override by env paddle-simple-cpu-worker-0:37777
LAUNCH WARNNING args nnodes is override by env 2
LAUNCH WARNNING args job_id is override by env paddle-simple-cpu
Prepare distributed training with 2 nodes 1 cards
I0823 15:03:14.107479    30 tcp_utils.cc:130] Successfully connected to 10.1.178.90:44959
2023-08-23 15:03:14,747-INFO: [topology.py:187:__init__] HybridParallelInfo: rank_id: 1, mp_degree: 1, sharding_degree: 1, pp_degree: 1, dp_degree: 2, mp_group: [1],  sharding_group: [1], pp_group: [1], dp_group: [0, 1], check/clip group: [1]
Distributed training start...
/usr/local/lib/python3.7/dist-packages/paddle/nn/layer/norm.py:676: UserWarning: When training, we now always track global mean and variance.
  "When training, we now always track global mean and variance.")
[Epoch 0, batch 0] loss: 3.99281, acc1: 0.00000, acc5: 0.00000
[Epoch 1, batch 0] loss: 64.00000, acc1: 0.00000, acc5: 0.00000
[Epoch 2, batch 0] loss: 64.64741, acc1: 0.00000, acc5: 0.00000
Distributed training completed

The logs of pod paddle-simple-cpu-worker-0:
 LAUNCH INFO 2023-08-23 15:03:10,457 Paddle Distributed Test begin...
LAUNCH INFO 2023-08-23 15:03:10,465 -----------  Configuration  ----------------------
LAUNCH INFO 2023-08-23 15:03:10,465 devices: None
LAUNCH INFO 2023-08-23 15:03:10,465 elastic_level: -1
LAUNCH INFO 2023-08-23 15:03:10,465 elastic_timeout: 30
LAUNCH INFO 2023-08-23 15:03:10,465 gloo_port: 6767
LAUNCH INFO 2023-08-23 15:03:10,465 host: None
LAUNCH INFO 2023-08-23 15:03:10,465 ips: None
LAUNCH INFO 2023-08-23 15:03:10,465 job_id: paddle-simple-cpu
LAUNCH INFO 2023-08-23 15:03:10,465 legacy: False
LAUNCH INFO 2023-08-23 15:03:10,465 log_dir: log
LAUNCH INFO 2023-08-23 15:03:10,465 log_level: INFO
LAUNCH INFO 2023-08-23 15:03:10,465 master: 10.1.178.90:37777
LAUNCH INFO 2023-08-23 15:03:10,465 max_restart: 3
LAUNCH INFO 2023-08-23 15:03:10,465 nnodes: 2
LAUNCH INFO 2023-08-23 15:03:10,465 nproc_per_node: None
LAUNCH INFO 2023-08-23 15:03:10,465 rank: -1
LAUNCH INFO 2023-08-23 15:03:10,465 run_mode: collective
LAUNCH INFO 2023-08-23 15:03:10,465 server_num: None
LAUNCH INFO 2023-08-23 15:03:10,465 servers: 
LAUNCH INFO 2023-08-23 15:03:10,465 start_port: 6070
LAUNCH INFO 2023-08-23 15:03:10,466 trainer_num: None
LAUNCH INFO 2023-08-23 15:03:10,466 trainers: 
LAUNCH INFO 2023-08-23 15:03:10,466 training_script: /usr/local/lib/python3.7/dist-packages/paddle/distributed/launch/plugins/test.py
LAUNCH INFO 2023-08-23 15:03:10,466 training_script_args: []
LAUNCH INFO 2023-08-23 15:03:10,466 with_gloo: 1
LAUNCH INFO 2023-08-23 15:03:10,466 --------------------------------------------------
LAUNCH INFO 2023-08-23 15:03:10,466 Job: paddle-simple-cpu, mode collective, replicas 2[2:2], elastic False
LAUNCH INFO 2023-08-23 15:03:10,466 Waiting peer start...
LAUNCH INFO 2023-08-23 15:03:11,869 Run Pod: gwiwvj, replicas 1, status ready
LAUNCH INFO 2023-08-23 15:03:11,908 Watching Pod: gwiwvj, replicas 1, status running
LAUNCH INFO 2023-08-23 15:03:20,921 Pod completed
LAUNCH INFO 2023-08-23 15:03:21,386 Exit code 0
LAUNCH WARNNING args master is override by env 10.1.178.90:37777
LAUNCH WARNNING args nnodes is override by env 2
LAUNCH WARNNING args job_id is override by env paddle-simple-cpu
Prepare distributed training with 2 nodes 1 cards
I0823 15:03:14.104984    30 tcp_utils.cc:181] The server starts to listen on IP_ANY:44959
I0823 15:03:14.105172    30 tcp_utils.cc:130] Successfully connected to 10.1.178.90:44959
2023-08-23 15:03:15,811-INFO: [topology.py:187:__init__] HybridParallelInfo: rank_id: 0, mp_degree: 1, sharding_degree: 1, pp_degree: 1, dp_degree: 2, mp_group: [0],  sharding_group: [0], pp_group: [0], dp_group: [0, 1], check/clip group: [0]
Distributed training start...
/usr/local/lib/python3.7/dist-packages/paddle/nn/layer/norm.py:676: UserWarning: When training, we now always track global mean and variance.
  "When training, we now always track global mean and variance.")
[Epoch 0, batch 0] loss: 1.05379, acc1: 1.00000, acc5: 1.00000
[Epoch 1, batch 0] loss: 64.00000, acc1: 0.00000, acc5: 0.00000
[Epoch 2, batch 0] loss: 64.66174, acc1: 0.00000, acc5: 0.00000
Distributed training completed
I0823 15:03:20.149217    46 tcp_store.cc:257] receive shutdown event and so quit from MasterDaemon run loop

None
Delete PaddleJob
Delete the created PaddleJob and check that all created resources were removed as well.

client.delete_paddlejob(name=PADDLEJOB_NAME)
PaddleJob admin/paddle-simple-cpu has been deleted
@retry(
    wait=wait_exponential(multiplier=2, min=1, max=10),
    stop=stop_after_attempt(30),
    reraise=True,
)
def assert_paddlejob_removed(client, job_name):
    """Wait for PaddleJob be removed."""
    # fetch the existing PaddleJob names
    # verify that the Job was deleted successfully
    jobs = {job.metadata.name for job in client.list_paddlejobs()}
    assert job_name not in jobs, f"Failed to delete PaddleJob {job_name}!"
# wait for PaddleJob to be removed successfully
assert_paddlejob_removed(client, PADDLEJOB_NAME)

</p>
</details>