### PR TITLE
feat: Add CI workflow for linting

### DIFF
--- a/.github/workflows/on_pull_or_push.yaml
+++ b/.github/workflows/on_pull_or_push.yaml
@@ -1,0 +1,17 @@
+name: On Pull Request or Push
+
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+    - track/**
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: python3 -m pip install tox
+      - run: tox -e lint


### PR DESCRIPTION
Add a Github CI workflow to execute the configured linting checks on pull requests and when pushing against the `main` or `track/*` branches.

This is expected to fail until https://github.com/canonical/charmed-kubeflow-uats/pull/21 is merged.

Closes #22