### PR TITLE
fix: pin minio<7.0

### DIFF
--- a/tests/notebooks/e2e-wine/requirements.in
+++ b/tests/notebooks/e2e-wine/requirements.in
@@ -2,7 +2,7 @@ boto3
 # pin to the latest <2.0 version to ensure compatibility
 # with the KFP API server version deployed in CKF 1.7
 kfp==1.8.22
-# pin to <7.0 for compatibility with the minio client
+# pin to <7.0 to avoid breaking changes in sdk
 minio<7.0
 # pin the client to match the version of the deployed MLflow server
 mlflow==2.1.1

--- a/tests/notebooks/e2e-wine/requirements.in
+++ b/tests/notebooks/e2e-wine/requirements.in
@@ -2,6 +2,7 @@ boto3
 # pin to the latest <2.0 version to ensure compatibility
 # with the KFP API server version deployed in CKF 1.7
 kfp==1.8.22
+# pin to <7.0 for compatibility with the minio client
 minio<7.0
 # pin the client to match the version of the deployed MLflow server
 mlflow==2.1.1

--- a/tests/notebooks/e2e-wine/requirements.in
+++ b/tests/notebooks/e2e-wine/requirements.in
@@ -2,7 +2,7 @@ boto3
 # pin to the latest <2.0 version to ensure compatibility
 # with the KFP API server version deployed in CKF 1.7
 kfp==1.8.22
-minio
+minio<7.0
 # pin the client to match the version of the deployed MLflow server
 mlflow==2.1.1
 numpy

--- a/tests/notebooks/e2e-wine/requirements.txt
+++ b/tests/notebooks/e2e-wine/requirements.txt
@@ -42,6 +42,8 @@ cloudpickle==2.2.1
     #   kfp
     #   mlflow
     #   shap
+configparser==6.0.0
+    # via minio
 contourpy==1.1.1
     # via matplotlib
 cycler==0.11.0
@@ -157,7 +159,7 @@ markupsafe==2.1.3
     #   werkzeug
 matplotlib==3.7.3
     # via mlflow
-minio==7.1.16
+minio==6.0.2
     # via -r requirements.in
 mlflow==2.1.1
     # via -r requirements.in
@@ -224,9 +226,11 @@ python-dateutil==2.8.2
     #   kfp-server-api
     #   kubernetes
     #   matplotlib
+    #   minio
     #   pandas
 pytz==2022.7.1
     # via
+    #   minio
     #   mlflow
     #   pandas
 pyyaml==6.0.1

--- a/tests/notebooks/minio/requirements.in
+++ b/tests/notebooks/minio/requirements.in
@@ -1,4 +1,4 @@
-# pin to <7.0 for compatibility with the minio client
+# pin to <7.0 to avoid breaking changes in sdk
 minio<7.0
 pandas
 s3fs

--- a/tests/notebooks/minio/requirements.in
+++ b/tests/notebooks/minio/requirements.in
@@ -1,3 +1,3 @@
-minio
+minio<7.0
 pandas
 s3fs

--- a/tests/notebooks/minio/requirements.in
+++ b/tests/notebooks/minio/requirements.in
@@ -1,3 +1,4 @@
+# pin to <7.0 for compatibility with the minio client
 minio<7.0
 pandas
 s3fs

--- a/tests/notebooks/minio/requirements.txt
+++ b/tests/notebooks/minio/requirements.txt
@@ -24,6 +24,8 @@ certifi==2023.7.22
     # via minio
 charset-normalizer==3.2.0
     # via aiohttp
+configparser==6.0.0
+    # via minio
 frozenlist==1.4.0
     # via
     #   aiohttp
@@ -34,7 +36,7 @@ idna==3.4
     # via yarl
 jmespath==1.0.1
     # via botocore
-minio==7.1.16
+minio==6.0.2
     # via -r requirements.in
 multidict==6.0.4
     # via
@@ -47,9 +49,12 @@ pandas==2.0.3
 python-dateutil==2.8.2
     # via
     #   botocore
+    #   minio
     #   pandas
 pytz==2023.3.post1
-    # via pandas
+    # via
+    #   minio
+    #   pandas
 s3fs==2023.9.1
     # via -r requirements.in
 six==1.16.0

--- a/tests/notebooks/mlflow/requirements.in
+++ b/tests/notebooks/mlflow/requirements.in
@@ -1,5 +1,5 @@
 boto3
-minio
+minio<7.0
 # pin the client to match the version of the deployed MLflow server
 mlflow==2.1.1
 tenacity

--- a/tests/notebooks/mlflow/requirements.in
+++ b/tests/notebooks/mlflow/requirements.in
@@ -1,4 +1,5 @@
 boto3
+# pin to <7.0 for compatibility with the minio client
 minio<7.0
 # pin the client to match the version of the deployed MLflow server
 mlflow==2.1.1

--- a/tests/notebooks/mlflow/requirements.in
+++ b/tests/notebooks/mlflow/requirements.in
@@ -1,5 +1,5 @@
 boto3
-# pin to <7.0 for compatibility with the minio client
+# pin to <7.0 to avoid breaking changes in sdk
 minio<7.0
 # pin the client to match the version of the deployed MLflow server
 mlflow==2.1.1

--- a/tests/notebooks/mlflow/requirements.txt
+++ b/tests/notebooks/mlflow/requirements.txt
@@ -29,6 +29,8 @@ cloudpickle==2.2.1
     # via
     #   mlflow
     #   shap
+configparser==6.0.0
+    # via minio
 contourpy==1.1.1
     # via matplotlib
 cycler==0.11.0
@@ -91,7 +93,7 @@ markupsafe==2.1.3
     #   werkzeug
 matplotlib==3.7.3
     # via mlflow
-minio==7.1.16
+minio==6.0.2
     # via -r requirements.in
 mlflow==2.1.1
     # via -r requirements.in
@@ -134,9 +136,11 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   matplotlib
+    #   minio
     #   pandas
 pytz==2022.7.1
     # via
+    #   minio
     #   mlflow
     #   pandas
 pyyaml==6.0.1


### PR DESCRIPTION
minio sdk 7.0 is a breaking release that deprecates `BucketAlreadyOwnedByYou` and `BucketAlreadyExists` errors that we are using in the UATs. See issue https://github.com/minio/minio-py/issues/1051.
since we are using an old version of minio, it makes sense to pin the sdk to an older version.