### PR TITLE
fix: kserve prediction url

### DIFF
--- a/tests/notebooks/kserve/kserve-integration.ipynb
+++ b/tests/notebooks/kserve/kserve-integration.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2b1c430f-1b3c-4c18-b5b3-0b3757f01259",
    "metadata": {},
@@ -14,6 +15,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "26ac0a3d-10ee-4f92-a9e0-e1b5c550bd8b",
    "metadata": {},
@@ -23,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "9fbb8bc8-0eb0-4853-bef6-e2098eb2829c",
    "metadata": {
     "tags": [
@@ -36,6 +38,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "306c9dc8-2ee7-4d2d-bbf8-38f4fadd3c73",
    "metadata": {},
@@ -45,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "715c03bb-ef5a-4468-a370-a106f44061bc",
    "metadata": {},
    "outputs": [],
@@ -65,6 +68,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2d29d9ed-dd6e-474c-93f9-dceaa25109d4",
    "metadata": {},
@@ -74,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "2e10aac9-72ed-4ff6-a089-60b821d06911",
    "metadata": {},
    "outputs": [],
@@ -84,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "c4f6a4fb-a21c-49cc-8b4f-100fff22b0d3",
    "metadata": {},
    "outputs": [],
@@ -107,6 +111,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6348b4c0-42d0-4dc1-bdb4-8f686bcdbbb7",
    "metadata": {},
@@ -115,6 +120,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b3ed57ac-2170-4b60-949d-898cb7787e52",
    "metadata": {},
@@ -124,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "35dc21f1-d3c4-4693-867b-2ebfd141c161",
    "metadata": {},
    "outputs": [],
@@ -133,6 +139,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6f12f22a-5aca-40bf-9930-e68c0fc3ee85",
    "metadata": {},
@@ -142,50 +149,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "f02a6871-da47-4f55-b7d3-80da300488f1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'apiVersion': 'serving.kserve.io/v1beta1',\n",
-       " 'kind': 'InferenceService',\n",
-       " 'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'},\n",
-       "  'creationTimestamp': '2023-08-07T09:50:16Z',\n",
-       "  'generation': 1,\n",
-       "  'managedFields': [{'apiVersion': 'serving.kserve.io/v1beta1',\n",
-       "    'fieldsType': 'FieldsV1',\n",
-       "    'fieldsV1': {'f:metadata': {'f:annotations': {'.': {},\n",
-       "       'f:sidecar.istio.io/inject': {}}},\n",
-       "     'f:spec': {'.': {},\n",
-       "      'f:predictor': {'.': {},\n",
-       "       'f:sklearn': {'.': {}, 'f:name': {}, 'f:storageUri': {}}}}},\n",
-       "    'manager': 'OpenAPI-Generator',\n",
-       "    'operation': 'Update',\n",
-       "    'time': '2023-08-07T09:50:14Z'}],\n",
-       "  'name': 'sklearn-iris',\n",
-       "  'namespace': 'test',\n",
-       "  'resourceVersion': '56838',\n",
-       "  'uid': 'ece28eaa-802a-45ce-a71d-22af323a3528'},\n",
-       " 'spec': {'predictor': {'model': {'modelFormat': {'name': 'sklearn'},\n",
-       "    'name': '',\n",
-       "    'resources': {},\n",
-       "    'storageUri': 'gs://kfserving-examples/models/sklearn/1.0/model'}}}}"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "client.create(isvc)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "e8cb648e-bf9d-455e-a40e-022c35772aa3",
    "metadata": {},
    "outputs": [],
@@ -202,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "50871dc2-9ef1-4458-813b-2d9dca03c6a1",
    "metadata": {
     "tags": [
@@ -215,6 +189,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1c03aeca-0828-4db1-9051-88eb25a26277",
    "metadata": {},
@@ -224,18 +199,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "8522c4e9-07b7-4bff-9b49-3675ff19bacc",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inference URL: http://sklearn-iris.test.svc.cluster.local/v1/models/sklearn-iris:predict\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "isvc_resp = client.get(ISVC_NAME)\n",
     "isvc_url = isvc_resp['status']['address']['url']\n",
@@ -243,6 +210,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2557d625-b08f-4086-9626-2c4cd8dabe66",
    "metadata": {},
@@ -252,18 +220,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "4ef27af2-9ae0-4adf-9058-ecc5ac84ef24",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\"predictions\":[1,1]}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "inference_input = {\n",
     "  \"instances\": [\n",
@@ -271,13 +231,13 @@
     "    [6.0,  3.4,  4.5,  1.6]\n",
     "  ]\n",
     "}\n",
-    "response = requests.post(isvc_url, json=inference_input)\n",
+    "response = requests.post(f\"{isvc_url}/v1/models/sklearn-iris:predict\", json=inference_input)\n",
     "print(response.text)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "9559d383-8124-4201-b160-bd8cc7784d48",
    "metadata": {
     "tags": [
@@ -293,6 +253,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a7c75c2c-0be2-4055-a09c-0a0da616a3b8",
    "metadata": {},
@@ -302,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "a8d14051-decb-4c14-bc16-7ea04c3dd371",
    "metadata": {},
    "outputs": [],
@@ -312,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "95ae1ec2-7275-4e02-a193-3a19f7501637",
    "metadata": {
     "tags": []
@@ -336,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "b0961b27-6c5e-43ea-bbcc-241c925a7839",
    "metadata": {
     "tags": [


### PR DESCRIPTION
- closes https://github.com/canonical/kserve-operators/issues/182
- clears the output of the kserve test notebook