### PR TITLE
kserve-integration: Add `serveless` compatibility note

### DIFF
--- a/tests/notebooks/kserve/kserve-integration.ipynb
+++ b/tests/notebooks/kserve/kserve-integration.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Test KServe Integration\n",
     "\n",
-    "This example notebook is loosely based on [this](https://github.com/kubeflow/examples/blob/master/kserve/sdk/first_isvc_kserve.ipynb) upstream example.\n",
+    "This example notebook is loosely based on [this](https://github.com/kubeflow/examples/blob/master/kserve/sdk/first_isvc_kserve.ipynb) upstream example. Note that this only works with `Serverless` deployment mode at the moment.\n",
     "\n",
     "- create Inference Service\n",
     "- perform inference"


### PR DESCRIPTION
Add note that UAT notebook is only compatible with serverless deployment mode at the moment.
This note is also present in the notebook's PR https://github.com/canonical/charmed-kubeflow-uats/pull/10.
Closes https://github.com/canonical/charmed-kubeflow-uats/issues/47