### PR TITLE
fix: Initialise lightkube with `trust_env=False`

### DIFF
--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -48,7 +48,7 @@ def pytest_cmd(pytest_filter):
 @pytest.fixture(scope="module")
 def lightkube_client():
     """Initialise Lightkube Client."""
-    lightkube_client = Client()
+    lightkube_client = Client(trust_env=False)
     load_in_cluster_generic_resources(lightkube_client)
     return lightkube_client
 

--- a/driver/utils.py
+++ b/driver/utils.py
@@ -87,5 +87,5 @@ def fetch_job_logs(job_name, namespace):
 
 def delete_job(job_name, namespace, lightkube_client=None):
     """Delete a Kubernetes Job."""
-    client = lightkube_client or Client()
+    client = lightkube_client or Client(trust_env=False)
     client.delete(Job, name=job_name, namespace=namespace)

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 # Pinning to <3.0 to ensure compatibility with the 2.9 controller version
 # Note: 3.0 is not being maintained anymore
-juju<3.0
+juju
 lightkube
 pytest
 pytest-operator

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,4 @@
-# Pinning to <3.0 to ensure compatibility with the 2.9 controller version
-# Note: 3.0 is not being maintained anymore
-juju
+juju<4.0
 lightkube
 pytest
 pytest-operator

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,14 +5,14 @@
 #    pip-compile requirements.in
 #
 anyio==4.0.0
-    # via httpcore
-asttokens==2.4.0
+    # via httpx
+asttokens==2.4.1
     # via stack-data
 backcall==0.2.0
     # via ipython
 bcrypt==4.0.1
     # via paramiko
-cachetools==5.3.1
+cachetools==5.3.2
     # via google-auth
 certifi==2023.7.22
     # via
@@ -20,13 +20,13 @@ certifi==2023.7.22
     #   httpx
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
-cryptography==41.0.3
+cryptography==41.0.5
     # via paramiko
 decorator==5.1.1
     # via
@@ -36,16 +36,18 @@ exceptiongroup==1.1.3
     # via
     #   anyio
     #   pytest
-executing==1.2.0
+executing==2.0.1
     # via stack-data
-google-auth==2.23.0
+google-auth==2.23.4
     # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==0.18.0
+httpcore==1.0.2
     # via httpx
-httpx==0.25.0
+httpx==0.25.1
     # via lightkube
+hvac==2.0.0
+    # via juju
 idna==3.4
     # via
     #   anyio
@@ -55,28 +57,24 @@ iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.12.2
+ipython==8.12.3
     # via ipdb
-jedi==0.19.0
+jedi==0.19.1
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==2.9.44.1
+juju==3.2.3.0
     # via
     #   -r requirements.in
     #   pytest-operator
-jujubundlelib==0.5.7
-    # via theblues
 kubernetes==28.1.0
     # via juju
-lightkube==0.14.0
+lightkube==0.15.0
     # via -r requirements.in
 lightkube-models==1.28.1.4
     # via lightkube
 macaroonbakery==1.3.1
-    # via
-    #   juju
-    #   theblues
+    # via juju
 markupsafe==2.1.3
     # via jinja2
 matplotlib-inline==0.1.6
@@ -87,7 +85,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-packaging==23.1
+packaging==23.2
     # via pytest
 paramiko==2.12.0
     # via juju
@@ -99,7 +97,7 @@ pickleshare==0.7.5
     # via ipython
 pluggy==1.3.0
     # via pytest
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.41
     # via ipython
 protobuf==3.20.3
     # via macaroonbakery
@@ -129,14 +127,14 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r requirements.in
     #   pytest-asyncio
     #   pytest-operator
 pytest-asyncio==0.21.1
     # via pytest-operator
-pytest-operator==0.29.0
+pytest-operator==0.31.0
     # via -r requirements.in
 python-dateutil==2.8.2
     # via kubernetes
@@ -145,16 +143,15 @@ pytz==2023.3.post1
 pyyaml==6.0.1
     # via
     #   juju
-    #   jujubundlelib
     #   kubernetes
     #   lightkube
     #   pytest-operator
 requests==2.31.0
     # via
+    #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
-    #   theblues
 requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
@@ -170,21 +167,18 @@ six==1.16.0
 sniffio==1.3.0
     # via
     #   anyio
-    #   httpcore
     #   httpx
-stack-data==0.6.2
+stack-data==0.6.3
     # via ipython
 tenacity==8.2.3
     # via -r requirements.in
-theblues==0.5.2
-    # via juju
 tomli==2.0.1
     # via
     #   ipdb
     #   pytest
 toposort==1.10
     # via juju
-traitlets==5.10.0
+traitlets==5.13.0
     # via
     #   ipython
     #   matplotlib-inline
@@ -194,14 +188,13 @@ typing-extensions==4.8.0
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==1.26.16
+urllib3==1.26.18
     # via
-    #   google-auth
     #   kubernetes
     #   requests
-wcwidth==0.2.6
+wcwidth==0.2.10
     # via prompt-toolkit
-websocket-client==1.6.3
+websocket-client==1.6.4
     # via kubernetes
-websockets==7.0
+websockets==8.1
     # via juju


### PR DESCRIPTION
The addition of `trust_env=False` to lightkube allows the tests' kubernetes calls to ignore the proxy env variables and ping directly internal addresses. The rationale is explained in detail in https://github.com/canonical/charmed-kubeflow-uats/issues/27.
- Initialise lightkube with `trust_env=False` 
- Unpin juju since CKF latest/edge can be deployed in Juju 3.1

Refs #27