### PR TITLE
update katib-integration.ipynb to use a new katib experiment

### DIFF
--- a/tests/notebooks/katib/katib-integration.ipynb
+++ b/tests/notebooks/katib/katib-integration.ipynb
@@ -46,7 +46,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from kubeflow.katib import (\n",
@@ -77,7 +79,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "client = KatibClient()"
@@ -95,7 +99,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "EXPERIMENT_NAME = \"cmaes-example\""
@@ -104,7 +110,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "metadata = V1ObjectMeta(\n",
@@ -116,9 +124,9 @@
     ")\n",
     "\n",
     "objective_spec=V1beta1ObjectiveSpec(\n",
-    "    type=\"maximize\",\n",
-    "    goal= 0.99,\n",
-    "    objective_metric_name=\"Validation-accuracy\",\n",
+    "    type=\"minimize\",\n",
+    "    goal= 0.001,\n",
+    "    objective_metric_name=\"loss\",\n",
     "    additional_metric_names=[\"Train-accuracy\"]\n",
     ")\n",
     "\n",
@@ -134,18 +142,11 @@
     "        ),\n",
     "    ),\n",
     "    V1beta1ParameterSpec(\n",
-    "        name=\"num-layers\",\n",
-    "        parameter_type=\"int\",\n",
+    "        name=\"momentum\",\n",
+    "        parameter_type=\"double\",\n",
     "        feasible_space=V1beta1FeasibleSpace(\n",
-    "            min=\"2\",\n",
-    "            max=\"5\"\n",
-    "        ),\n",
-    "    ),\n",
-    "    V1beta1ParameterSpec(\n",
-    "        name=\"optimizer\",\n",
-    "        parameter_type=\"categorical\",\n",
-    "        feasible_space=V1beta1FeasibleSpace(\n",
-    "            list=[\"sgd\", \"adam\", \"ftrl\"]\n",
+    "            min=\"0.5\",\n",
+    "            max=\"0.9\"\n",
     "        ),\n",
     "    ),\n",
     "]\n",
@@ -165,15 +166,14 @@
     "                \"containers\": [\n",
     "                    {\n",
     "                        \"name\": \"training-container\",\n",
-    "                        \"image\": \"docker.io/kubeflowkatib/mxnet-mnist:v0.14.0\",\n",
+    "                        \"image\": \"docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.14.0\",\n",
     "                        \"command\": [\n",
     "                            \"python3\",\n",
-    "                            \"/opt/mxnet-mnist/mnist.py\",\n",
+    "                            \"/opt/pytorch-mnist/mnist.py\",\n",
+    "                            \"--epochs=1\",\n",
     "                            \"--batch-size=64\",\n",
-    "                            \"--num-epochs=1\",\n",
     "                            \"--lr=${trialParameters.learningRate}\",\n",
-    "                            \"--num-layers=${trialParameters.numberLayers}\",\n",
-    "                            \"--optimizer=${trialParameters.optimizer}\"\n",
+    "                            \"--momentum=${trialParameters.momentum}\",\n",
     "                        ]\n",
     "                    }\n",
     "                ],\n",
@@ -192,14 +192,9 @@
     "            reference=\"lr\"\n",
     "        ),\n",
     "        V1beta1TrialParameterSpec(\n",
-    "            name=\"numberLayers\",\n",
-    "            description=\"Number of training model layers\",\n",
-    "            reference=\"num-layers\"\n",
-    "        ),\n",
-    "        V1beta1TrialParameterSpec(\n",
-    "            name=\"optimizer\",\n",
-    "            description=\"Training model optimizer (sdg, adam or ftrl)\",\n",
-    "            reference=\"optimizer\"\n",
+    "            name=\"momentum\",\n",
+    "            description=\"Momentum for the training model\",\n",
+    "            reference=\"momentum\"\n",
     "        ),\n",
     "    ],\n",
     "    trial_spec=trial_spec\n",
@@ -232,7 +227,8 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "tags": []
    },
    "outputs": [
     {
@@ -241,11 +237,10 @@
      "text": [
       "Name: cmaes-example\n",
       "Algorithm: cmaes\n",
-      "Objective: Validation-accuracy\n",
+      "Objective: loss\n",
       "Trial Parameters:\n",
       "- learningRate: Learning rate for the training model\n",
-      "- numberLayers: Number of training model layers\n",
-      "- optimizer: Training model optimizer (sdg, adam or ftrl)\n",
+      "- momentum: Momentum for the training model\n",
       "Max Trial Count: 3\n",
       "Max Failed Trial Count: 1\n",
       "Parallel Trial Count: 2\n"
@@ -276,7 +271,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -305,19 +302,21 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Experiment test/cmaes-example has been created\n"
+      "Experiment user/cmaes-example has been created\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "Katib Experiment cmaes-example link <a href=\"/_/katib/#/katib/hp_monitor/test/cmaes-example\" target=\"_blank\">here</a>"
+       "Katib Experiment cmaes-example link <a href=\"/_/katib/#/katib/hp_monitor/user/cmaes-example\" target=\"_blank\">here</a>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -344,7 +343,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "@retry(\n",
@@ -379,7 +380,8 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "tags": []
    },
    "outputs": [
     {
@@ -398,13 +400,12 @@
       "                            'source': None},\n",
       " 'nas_config': None,\n",
       " 'objective': {'additional_metric_names': ['Train-accuracy'],\n",
-      "               'goal': 0.99,\n",
-      "               'metric_strategies': [{'name': 'Validation-accuracy',\n",
-      "                                      'value': 'max'},\n",
+      "               'goal': 0.001,\n",
+      "               'metric_strategies': [{'name': 'loss', 'value': 'min'},\n",
       "                                     {'name': 'Train-accuracy',\n",
-      "                                      'value': 'max'}],\n",
-      "               'objective_metric_name': 'Validation-accuracy',\n",
-      "               'type': 'maximize'},\n",
+      "                                      'value': 'min'}],\n",
+      "               'objective_metric_name': 'loss',\n",
+      "               'type': 'minimize'},\n",
       " 'parallel_trial_count': 2,\n",
       " 'parameters': [{'feasible_space': {'list': None,\n",
       "                                    'max': '0.06',\n",
@@ -413,17 +414,11 @@
       "                 'name': 'lr',\n",
       "                 'parameter_type': 'double'},\n",
       "                {'feasible_space': {'list': None,\n",
-      "                                    'max': '5',\n",
-      "                                    'min': '2',\n",
+      "                                    'max': '0.9',\n",
+      "                                    'min': '0.5',\n",
       "                                    'step': None},\n",
-      "                 'name': 'num-layers',\n",
-      "                 'parameter_type': 'int'},\n",
-      "                {'feasible_space': {'list': ['sgd', 'adam', 'ftrl'],\n",
-      "                                    'max': None,\n",
-      "                                    'min': None,\n",
-      "                                    'step': None},\n",
-      "                 'name': 'optimizer',\n",
-      "                 'parameter_type': 'categorical'}],\n",
+      "                 'name': 'momentum',\n",
+      "                 'parameter_type': 'double'}],\n",
       " 'resume_policy': 'Never',\n",
       " 'trial_template': {'config_map': None,\n",
       "                    'failure_condition': 'status.conditions.#(type==\"Failed\")#|#(status==\"True\")#',\n",
@@ -435,65 +430,57 @@
       "                                                         'the training model',\n",
       "                                          'name': 'learningRate',\n",
       "                                          'reference': 'lr'},\n",
-      "                                         {'description': 'Number of training '\n",
-      "                                                         'model layers',\n",
-      "                                          'name': 'numberLayers',\n",
-      "                                          'reference': 'num-layers'},\n",
-      "                                         {'description': 'Training model '\n",
-      "                                                         'optimizer (sdg, adam '\n",
-      "                                                         'or ftrl)',\n",
-      "                                          'name': 'optimizer',\n",
-      "                                          'reference': 'optimizer'}],\n",
+      "                                         {'description': 'Momentum for the '\n",
+      "                                                         'training model',\n",
+      "                                          'name': 'momentum',\n",
+      "                                          'reference': 'momentum'}],\n",
       "                    'trial_spec': {'apiVersion': 'batch/v1',\n",
       "                                   'kind': 'Job',\n",
       "                                   'spec': {'template': {'metadata': {'annotations': {'sidecar.istio.io/inject': 'false'}},\n",
       "                                                         'spec': {'containers': [{'command': ['python3',\n",
-      "                                                                                              '/opt/mxnet-mnist/mnist.py',\n",
+      "                                                                                              '/opt/pytorch-mnist/mnist.py',\n",
+      "                                                                                              '--epochs=1',\n",
       "                                                                                              '--batch-size=64',\n",
-      "                                                                                              '--num-epochs=1',\n",
       "                                                                                              '--lr=${trialParameters.learningRate}',\n",
-      "                                                                                              '--num-layers=${trialParameters.numberLayers}',\n",
-      "                                                                                              '--optimizer=${trialParameters.optimizer}'],\n",
-      "                                                                                  'image': 'docker.io/kubeflowkatib/mxnet-mnist:v0.14.0',\n",
+      "                                                                                              '--momentum=${trialParameters.momentum}'],\n",
+      "                                                                                  'image': 'docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.14.0',\n",
       "                                                                                  'name': 'training-container'}],\n",
       "                                                                  'restartPolicy': 'Never'}}}}}}\n",
       "\n",
       "Experiment Status:\n",
-      "{'completion_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
-      " 'conditions': [{'last_transition_time': datetime.datetime(2023, 7, 28, 12, 19, 37, tzinfo=tzlocal()),\n",
-      "                 'last_update_time': datetime.datetime(2023, 7, 28, 12, 19, 37, tzinfo=tzlocal()),\n",
+      "{'completion_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
+      " 'conditions': [{'last_transition_time': datetime.datetime(2024, 3, 25, 14, 53, 57, tzinfo=tzlocal()),\n",
+      "                 'last_update_time': datetime.datetime(2024, 3, 25, 14, 53, 57, tzinfo=tzlocal()),\n",
       "                 'message': 'Experiment is created',\n",
       "                 'reason': 'ExperimentCreated',\n",
       "                 'status': 'True',\n",
       "                 'type': 'Created'},\n",
-      "                {'last_transition_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
-      "                 'last_update_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
+      "                {'last_transition_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
+      "                 'last_update_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
       "                 'message': 'Experiment is running',\n",
       "                 'reason': 'ExperimentRunning',\n",
       "                 'status': 'False',\n",
       "                 'type': 'Running'},\n",
-      "                {'last_transition_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
-      "                 'last_update_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
+      "                {'last_transition_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
+      "                 'last_update_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
       "                 'message': 'Experiment has succeeded because max trial count '\n",
       "                            'has reached',\n",
       "                 'reason': 'ExperimentMaxTrialsReached',\n",
       "                 'status': 'True',\n",
       "                 'type': 'Succeeded'}],\n",
-      " 'current_optimal_trial': {'best_trial_name': 'cmaes-example-sw6zbt45',\n",
-      "                           'observation': {'metrics': [{'latest': '0.949940',\n",
-      "                                                        'max': '0.949940',\n",
-      "                                                        'min': '0.949940',\n",
-      "                                                        'name': 'Validation-accuracy'},\n",
-      "                                                       {'latest': '0.924324',\n",
-      "                                                        'max': '0.924324',\n",
-      "                                                        'min': '0.924324',\n",
+      " 'current_optimal_trial': {'best_trial_name': 'cmaes-example-dphxbch7',\n",
+      "                           'observation': {'metrics': [{'latest': '0.3130',\n",
+      "                                                        'max': '2.2980',\n",
+      "                                                        'min': '0.2691',\n",
+      "                                                        'name': 'loss'},\n",
+      "                                                       {'latest': 'unavailable',\n",
+      "                                                        'max': 'unavailable',\n",
+      "                                                        'min': 'unavailable',\n",
       "                                                        'name': 'Train-accuracy'}]},\n",
-      "                           'parameter_assignments': [{'name': 'optimizer',\n",
-      "                                                      'value': 'sgd'},\n",
-      "                                                     {'name': 'lr',\n",
-      "                                                      'value': '0.04188612100654'},\n",
-      "                                                     {'name': 'num-layers',\n",
-      "                                                      'value': '4'}]},\n",
+      "                           'parameter_assignments': [{'name': 'lr',\n",
+      "                                                      'value': '0.04511033252270099'},\n",
+      "                                                     {'name': 'momentum',\n",
+      "                                                      'value': '0.6980954001565728'}]},\n",
       " 'early_stopped_trial_list': None,\n",
       " 'failed_trial_list': None,\n",
       " 'killed_trial_list': None,\n",
@@ -501,10 +488,10 @@
       " 'metrics_unavailable_trial_list': None,\n",
       " 'pending_trial_list': None,\n",
       " 'running_trial_list': None,\n",
-      " 'start_time': datetime.datetime(2023, 7, 28, 12, 19, 37, tzinfo=tzlocal()),\n",
-      " 'succeeded_trial_list': ['cmaes-example-sw6zbt45',\n",
-      "                          'cmaes-example-vfc4ptmw',\n",
-      "                          'cmaes-example-kjrnx4k2'],\n",
+      " 'start_time': datetime.datetime(2024, 3, 25, 14, 53, 57, tzinfo=tzlocal()),\n",
+      " 'succeeded_trial_list': ['cmaes-example-9pjzlnzc',\n",
+      "                          'cmaes-example-dphxbch7',\n",
+      "                          'cmaes-example-7zhq4s49'],\n",
       " 'trial_metrics_unavailable': None,\n",
       " 'trials': 3,\n",
       " 'trials_early_stopped': None,\n",
@@ -536,24 +523,26 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[{'last_transition_time': datetime.datetime(2023, 7, 28, 12, 19, 37, tzinfo=tzlocal()),\n",
-      " 'last_update_time': datetime.datetime(2023, 7, 28, 12, 19, 37, tzinfo=tzlocal()),\n",
+      "[{'last_transition_time': datetime.datetime(2024, 3, 25, 14, 53, 57, tzinfo=tzlocal()),\n",
+      " 'last_update_time': datetime.datetime(2024, 3, 25, 14, 53, 57, tzinfo=tzlocal()),\n",
       " 'message': 'Experiment is created',\n",
       " 'reason': 'ExperimentCreated',\n",
       " 'status': 'True',\n",
-      " 'type': 'Created'}, {'last_transition_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
-      " 'last_update_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
+      " 'type': 'Created'}, {'last_transition_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
+      " 'last_update_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
       " 'message': 'Experiment is running',\n",
       " 'reason': 'ExperimentRunning',\n",
       " 'status': 'False',\n",
-      " 'type': 'Running'}, {'last_transition_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
-      " 'last_update_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
+      " 'type': 'Running'}, {'last_transition_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
+      " 'last_update_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
       " 'message': 'Experiment has succeeded because max trial count has reached',\n",
       " 'reason': 'ExperimentMaxTrialsReached',\n",
       " 'status': 'True',\n",
@@ -592,23 +581,24 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'best_trial_name': 'cmaes-example-sw6zbt45',\n",
-       " 'observation': {'metrics': [{'latest': '0.949940',\n",
-       "                              'max': '0.949940',\n",
-       "                              'min': '0.949940',\n",
-       "                              'name': 'Validation-accuracy'},\n",
-       "                             {'latest': '0.924324',\n",
-       "                              'max': '0.924324',\n",
-       "                              'min': '0.924324',\n",
+       "{'best_trial_name': 'cmaes-example-dphxbch7',\n",
+       " 'observation': {'metrics': [{'latest': '0.3130',\n",
+       "                              'max': '2.2980',\n",
+       "                              'min': '0.2691',\n",
+       "                              'name': 'loss'},\n",
+       "                             {'latest': 'unavailable',\n",
+       "                              'max': 'unavailable',\n",
+       "                              'min': 'unavailable',\n",
        "                              'name': 'Train-accuracy'}]},\n",
-       " 'parameter_assignments': [{'name': 'optimizer', 'value': 'sgd'},\n",
-       "                           {'name': 'lr', 'value': '0.04188612100654'},\n",
-       "                           {'name': 'num-layers', 'value': '4'}]}"
+       " 'parameter_assignments': [{'name': 'lr', 'value': '0.04511033252270099'},\n",
+       "                           {'name': 'momentum', 'value': '0.6980954001565728'}]}"
       ]
      },
      "execution_count": 14,
@@ -633,35 +623,36 @@
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trial: cmaes-example-sw6zbt45\n",
+      "Trial: cmaes-example-dphxbch7\n",
       "Trial Status:\n",
-      "{'last_transition_time': datetime.datetime(2023, 7, 28, 12, 20, 33, tzinfo=tzlocal()),\n",
-      " 'last_update_time': datetime.datetime(2023, 7, 28, 12, 20, 33, tzinfo=tzlocal()),\n",
+      "{'last_transition_time': datetime.datetime(2024, 3, 25, 14, 55, 25, tzinfo=tzlocal()),\n",
+      " 'last_update_time': datetime.datetime(2024, 3, 25, 14, 55, 25, tzinfo=tzlocal()),\n",
       " 'message': 'Trial has succeeded',\n",
       " 'reason': 'TrialSucceeded',\n",
       " 'status': 'True',\n",
       " 'type': 'Succeeded'}\n",
       "\n",
-      "Trial: cmaes-example-vfc4ptmw\n",
+      "Trial: cmaes-example-9pjzlnzc\n",
       "Trial Status:\n",
-      "{'last_transition_time': datetime.datetime(2023, 7, 28, 12, 20, 37, tzinfo=tzlocal()),\n",
-      " 'last_update_time': datetime.datetime(2023, 7, 28, 12, 20, 37, tzinfo=tzlocal()),\n",
+      "{'last_transition_time': datetime.datetime(2024, 3, 25, 14, 55, 27, tzinfo=tzlocal()),\n",
+      " 'last_update_time': datetime.datetime(2024, 3, 25, 14, 55, 27, tzinfo=tzlocal()),\n",
       " 'message': 'Trial has succeeded',\n",
       " 'reason': 'TrialSucceeded',\n",
       " 'status': 'True',\n",
       " 'type': 'Succeeded'}\n",
       "\n",
-      "Trial: cmaes-example-kjrnx4k2\n",
+      "Trial: cmaes-example-7zhq4s49\n",
       "Trial Status:\n",
-      "{'last_transition_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
-      " 'last_update_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
+      "{'last_transition_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
+      " 'last_update_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
       " 'message': 'Trial has succeeded',\n",
       " 'reason': 'TrialSucceeded',\n",
       " 'status': 'True',\n",
@@ -707,7 +698,9 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -724,60 +717,54 @@
       "Suggestion Status:\n",
       "{'algorithm_settings': None,\n",
       " 'completion_time': None,\n",
-      " 'conditions': [{'last_transition_time': datetime.datetime(2023, 7, 28, 12, 19, 37, tzinfo=tzlocal()),\n",
-      "                 'last_update_time': datetime.datetime(2023, 7, 28, 12, 19, 37, tzinfo=tzlocal()),\n",
+      " 'conditions': [{'last_transition_time': datetime.datetime(2024, 3, 25, 14, 53, 57, tzinfo=tzlocal()),\n",
+      "                 'last_update_time': datetime.datetime(2024, 3, 25, 14, 53, 57, tzinfo=tzlocal()),\n",
       "                 'message': 'Suggestion is created',\n",
       "                 'reason': 'SuggestionCreated',\n",
       "                 'status': 'True',\n",
       "                 'type': 'Created'},\n",
-      "                {'last_transition_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
-      "                 'last_update_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
+      "                {'last_transition_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
+      "                 'last_update_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
       "                 'message': 'Suggestion is not running',\n",
       "                 'reason': 'Suggestion is succeeded',\n",
       "                 'status': 'False',\n",
       "                 'type': 'Running'},\n",
-      "                {'last_transition_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
-      "                 'last_update_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
+      "                {'last_transition_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
+      "                 'last_update_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
       "                 'message': 'Deployment is not ready',\n",
       "                 'reason': 'Suggestion is succeeded',\n",
       "                 'status': 'False',\n",
       "                 'type': 'DeploymentReady'},\n",
-      "                {'last_transition_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
-      "                 'last_update_time': datetime.datetime(2023, 7, 28, 12, 21, 2, tzinfo=tzlocal()),\n",
+      "                {'last_transition_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
+      "                 'last_update_time': datetime.datetime(2024, 3, 25, 14, 55, 58, tzinfo=tzlocal()),\n",
       "                 'message': \"Suggestion is succeeded, can't be restarted\",\n",
       "                 'reason': 'Experiment is succeeded',\n",
       "                 'status': 'True',\n",
       "                 'type': 'Succeeded'}],\n",
       " 'last_reconcile_time': None,\n",
-      " 'start_time': datetime.datetime(2023, 7, 28, 12, 19, 37, tzinfo=tzlocal()),\n",
+      " 'start_time': datetime.datetime(2024, 3, 25, 14, 53, 57, tzinfo=tzlocal()),\n",
       " 'suggestion_count': 3,\n",
       " 'suggestions': [{'early_stopping_rules': None,\n",
       "                  'labels': None,\n",
-      "                  'name': 'cmaes-example-sw6zbt45',\n",
-      "                  'parameter_assignments': [{'name': 'optimizer',\n",
-      "                                             'value': 'sgd'},\n",
-      "                                            {'name': 'lr',\n",
+      "                  'name': 'cmaes-example-9pjzlnzc',\n",
+      "                  'parameter_assignments': [{'name': 'lr',\n",
       "                                             'value': '0.04188612100654'},\n",
-      "                                            {'name': 'num-layers',\n",
-      "                                             'value': '4'}]},\n",
+      "                                            {'name': 'momentum',\n",
+      "                                             'value': '0.7043612817216396'}]},\n",
       "                 {'early_stopping_rules': None,\n",
       "                  'labels': None,\n",
-      "                  'name': 'cmaes-example-vfc4ptmw',\n",
+      "                  'name': 'cmaes-example-dphxbch7',\n",
       "                  'parameter_assignments': [{'name': 'lr',\n",
       "                                             'value': '0.04511033252270099'},\n",
-      "                                            {'name': 'num-layers',\n",
-      "                                             'value': '3'},\n",
-      "                                            {'name': 'optimizer',\n",
-      "                                             'value': 'adam'}]},\n",
+      "                                            {'name': 'momentum',\n",
+      "                                             'value': '0.6980954001565728'}]},\n",
       "                 {'early_stopping_rules': None,\n",
       "                  'labels': None,\n",
-      "                  'name': 'cmaes-example-kjrnx4k2',\n",
+      "                  'name': 'cmaes-example-7zhq4s49',\n",
       "                  'parameter_assignments': [{'name': 'lr',\n",
       "                                             'value': '0.02556132716757138'},\n",
-      "                                            {'name': 'num-layers',\n",
-      "                                             'value': '4'},\n",
-      "                                            {'name': 'optimizer',\n",
-      "                                             'value': 'ftrl'}]}]}\n",
+      "                                            {'name': 'momentum',\n",
+      "                                             'value': '0.701003503816815'}]}]}\n",
       "\n"
      ]
     }
@@ -814,13 +801,15 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Experiment test/cmaes-example has been deleted\n"
+      "Experiment user/cmaes-example has been deleted\n"
      ]
     }
    ],
@@ -831,7 +820,9 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "@retry(\n",
@@ -888,7 +879,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates the katib example to include changes to the [upstream example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/sdk/cmaes-and-resume-policies.ipynb) we based this test on.  These changes were needed because the previous version requires a docker container that no longer exists.

Closes #64

### Testing instructions:

I deployed a subset of Charmed Kubeflow using:

```
juju deploy istio-gateway --config kind=ingress --channel latest/edge --trust istio-ingressgateway
juju deploy istio-pilot --channel latest/edge --config default-gateway=kubeflow-gateway --trust
juju relate istio-pilot istio-ingressgateway


juju deploy kubeflow-roles --channel 1.8/stable --trust
juju deploy kubeflow-profiles --channel latest/edge --trust
juju deploy kubeflow-dashboard --channel latest/edge --trust
juju relate kubeflow-dashboard kubeflow-profiles
juju deploy admission-webhook --trust --channel 1.8/stable
juju relate istio-pilot:ingress kubeflow-dashboard:ingress
juju relate istio-pilot kubeflow-dashboard

juju deploy jupyter-ui --channel latest/edge --trust
juju deploy jupyter-controller --channel latest/edge --trust
juju relate istio-pilot jupyter-ui
juju relate kubeflow-dashboard:links jupyter-ui:dashboard-links

juju deploy katib-controller --channel 0.16/stable
juju deploy katib-db-manager --channel 0.16/stable --trust
juju deploy katib-ui --channel 0.16/stable --trust
juju deploy mysql-k8s --channel 8.0/stable --trust --constraints mem=2G katib-db
juju relate katib-db-manager:relational-db katib-db:database
juju relate istio-pilot katib-ui
juju relate kubeflow-dashboard:links katib-ui:dashboard-links
```

From that, I tested two ways:
1) By creating a notebook server, cloning this charmed-kubeflow-uats repo, and running through the notebook tests/notebooks/katib/katib-integration.ipynb manually
2) From my local machine, cloning this repo and running `tox -e uats -- --filter "katib"`

<details><summary>Results from (2)</summary>

```
tox -e uats -- --filter "katib"                                                                       [11:07:40] 
uats: install_deps> python -I -m pip install -r requirements.txt
uats: commands[0]> pytest -vv --tb native /home/scribs/code/canonical/charmed-kubeflow-uats/KF-5395-update-katib-test/driver/ -s --model kubeflow --filter katib
==================================================== test session starts ====================================================
platform linux -- Python 3.8.18, pytest-7.4.3, pluggy-1.3.0 -- /home/scribs/code/canonical/charmed-kubeflow-uats/KF-5395-update-katib-test/.tox/uats/bin/python
cachedir: .tox/uats/.pytest_cache
rootdir: /home/scribs/code/canonical/charmed-kubeflow-uats/KF-5395-update-katib-test
configfile: pyproject.toml
plugins: asyncio-0.21.1, anyio-4.0.0, operator-0.31.0
asyncio: mode=strict
collected 2 items                                                                                                           

driver/test_kubeflow_workloads.py::test_create_profile 
------------------------------------------------------ live log setup -------------------------------------------------------
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/apiextensions.k8s.io/v1/customresourcedefinitions "HTTP/1.1 200 OK"
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:59 Creating Profile test-kubeflow...
INFO     httpx:_client.py:1013 HTTP Request: POST https://192.168.0.145:16443/apis/kubeflow.org/v1/profiles "HTTP/1.1 201 Created"
------------------------------------------------------- live log call -------------------------------------------------------
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/kubeflow.org/v1/profiles/test-kubeflow "HTTP/1.1 200 OK"
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/api/v1/namespaces/test-kubeflow "HTTP/1.1 404 Not Found"
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/api/v1/namespaces/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:32 Waiting for namespace test-kubeflow to become 'Active': phase == Active
PASSED
driver/test_kubeflow_workloads.py::test_kubeflow_workloads 
------------------------------------------------------- live log call -------------------------------------------------------
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:100 Starting Kubernetes Job test-kubeflow/test-kubeflow to run notebook tests...
INFO     httpx:_client.py:1013 HTTP Request: POST https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs "HTTP/1.1 201 Created"
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == not ready)
INFO     utils:utils.py:40 Retrying in 2 seconds (attempts: 1)
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == not ready)
INFO     utils:utils.py:40 Retrying in 4 seconds (attempts: 2)
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == not ready)
INFO     utils:utils.py:40 Retrying in 8 seconds (attempts: 3)
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 16 seconds (attempts: 4)
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 5)
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 6)
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 7)
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 8)
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 9)
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 10)
INFO     httpx:_client.py:1013 HTTP Request: GET https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:69 Job test-kubeflow/test-kubeflow completed successfully!
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:123 Fetching Job logs...
============================= test session starts ==============================
platform linux -- Python 3.8.10, pytest-8.1.1, pluggy-1.4.0 -- /opt/conda/bin/python3.8
cachedir: .pytest_cache
rootdir: /tests
configfile: pytest.ini
plugins: anyio-3.6.2
collecting ... collected 9 items / 8 deselected / 1 selected

test_notebooks.py::test_notebook[katib-integration] 
-------------------------------- live log call ---------------------------------
INFO     test_notebooks:test_notebooks.py:44 Running katib-integration.ipynb...
PASSED                                                                   [100%]

================= 1 passed, 8 deselected in 137.94s (0:02:17) ==================
PASSED
----------------------------------------------------- live log teardown -----------------------------------------------------
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:72 Deleting Profile test-kubeflow...
INFO     httpx:_client.py:1013 HTTP Request: DELETE https://192.168.0.145:16443/apis/kubeflow.org/v1/profiles/test-kubeflow "HTTP/1.1 200 OK"
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:129 Deleting Job test-kubeflow/test-kubeflow...
INFO     httpx:_client.py:1013 HTTP Request: DELETE https://192.168.0.145:16443/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"


=============================================== 2 passed in 224.94s (0:03:44) ===============================================
  uats: OK (242.85=setup[16.95]+cmd[225.89] seconds)
  congratulations :) (242.95 seconds)
```

</details>