### PR TITLE
training-operator test: Update image

### DIFF
--- a/tests/notebooks/training/training-integration.ipynb
+++ b/tests/notebooks/training/training-integration.ipynb
@@ -417,7 +417,7 @@
    "source": [
     "PYTORCHJOB_NAME = \"pytorch-mnist-gloo\"\n",
     "PYTORCHJOB_CONTAINER = \"pytorch\"\n",
-    "PYTORCHJOB_IMAGE = \"kubeflowkatib/pytorch-mnist-cpu:v0.17.0-rc.1\"\n",
+    "PYTORCHJOB_IMAGE = \"kubeflowkatib/pytorch-mnist-cpu:v0.16.0\"\n",
     "# The image above should be updated with each release with the corresponding Katib version used in CKF release.\n",
     "# Note that instead of using the [image from training-operator repository](https://github.com/kubeflow/training-operator/blob/master/examples/pytorch/mnist/Dockerfile),\n",
     "# the one [from Katib](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/trial-images/pytorch-mnist/Dockerfile.cpu) is being used\n",

--- a/tests/notebooks/training/training-integration.ipynb
+++ b/tests/notebooks/training/training-integration.ipynb
@@ -434,7 +434,7 @@
     "    name=PYTORCHJOB_CONTAINER,\n",
     "    image=PYTORCHJOB_IMAGE,\n",
     "    args=[\"--backend\", \"gloo\", \"--epochs\", \"2\"],\n",
-    "    # Passing `epochos`argument since kubeflowkatib image defaults to 10.\n",
+    "    # Passing `epochs`argument since kubeflowkatib image defaults to 10.\n",
     ")\n",
     "\n",
     "replica_spec = V1ReplicaSpec(\n",

--- a/tests/notebooks/training/training-integration.ipynb
+++ b/tests/notebooks/training/training-integration.ipynb
@@ -415,10 +415,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PYTORCHJOB_NAME = \"pytorch-dist-mnist-gloo\"\n",
+    "PYTORCHJOB_NAME = \"pytorch-mnist-gloo\"\n",
     "PYTORCHJOB_CONTAINER = \"pytorch\"\n",
-    "PYTORCHJOB_IMAGE = \"kubeflow/pytorch-dist-mnist:v1-3a360ba\"\n",
-    "# The image above should be updated with each release with the latest available in the registry."
+    "PYTORCHJOB_IMAGE = \"kubeflowkatib/pytorch-mnist-cpu:v1beta1-57ed828\"\n",
+    "# The image above should be updated with each release with the latest available in the registry.\n",
+    "# Note that instead of using the [image from training-operator repository](https://github.com/kubeflow/training-operator/blob/master/examples/pytorch/mnist/Dockerfile),\n",
+    "# the one [from Katib](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/trial-images/pytorch-mnist/Dockerfile.cpu) is being used\n",
+    "# due to the large size of the first one."
    ]
   },
   {
@@ -430,7 +433,7 @@
     "container = V1Container(\n",
     "    name=PYTORCHJOB_CONTAINER,\n",
     "    image=PYTORCHJOB_IMAGE,\n",
-    "    args=[\"--backend\", \"gloo\"],\n",
+    "    args=[\"--backend\", \"gloo\", \"--epochs\", \"2\"],\n",
     ")\n",
     "\n",
     "replica_spec = V1ReplicaSpec(\n",

--- a/tests/notebooks/training/training-integration.ipynb
+++ b/tests/notebooks/training/training-integration.ipynb
@@ -434,6 +434,7 @@
     "    name=PYTORCHJOB_CONTAINER,\n",
     "    image=PYTORCHJOB_IMAGE,\n",
     "    args=[\"--backend\", \"gloo\", \"--epochs\", \"2\"],\n",
+    "    # Passing `epochos`argument since kubeflowkatib image defaults to 10.\n",
     ")\n",
     "\n",
     "replica_spec = V1ReplicaSpec(\n",

--- a/tests/notebooks/training/training-integration.ipynb
+++ b/tests/notebooks/training/training-integration.ipynb
@@ -417,8 +417,8 @@
    "source": [
     "PYTORCHJOB_NAME = \"pytorch-mnist-gloo\"\n",
     "PYTORCHJOB_CONTAINER = \"pytorch\"\n",
-    "PYTORCHJOB_IMAGE = \"kubeflowkatib/pytorch-mnist-cpu:v1beta1-57ed828\"\n",
-    "# The image above should be updated with each release with the latest available in the registry.\n",
+    "PYTORCHJOB_IMAGE = \"kubeflowkatib/pytorch-mnist-cpu:v0.17.0-rc.1\"\n",
+    "# The image above should be updated with each release with the corresponding Katib version used in CKF release.\n",
     "# Note that instead of using the [image from training-operator repository](https://github.com/kubeflow/training-operator/blob/master/examples/pytorch/mnist/Dockerfile),\n",
     "# the one [from Katib](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/trial-images/pytorch-mnist/Dockerfile.cpu) is being used\n",
     "# due to the large size of the first one."


### PR DESCRIPTION
Update the image to use one from katib repository, which is [2.75GB](https://hub.docker.com/layers/kubeflowkatib/pytorch-mnist-cpu/v1beta1-57ed828/images/sha256-27ba519167619c42f6810238e3c911f0d8e309f2204021dab96bd9df65e4b280?context=explore) instead of 10GB that the previous one was. The new image is being built from this [Dockerfile](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/trial-images/pytorch-mnist/Dockerfile.cpu),

Closes #69