### PR TITLE
fix(katib): Increase experiment batch-size

### DIFF
--- a/tests/notebooks/katib/katib-integration.ipynb
+++ b/tests/notebooks/katib/katib-integration.ipynb
@@ -172,7 +172,7 @@
     "                            \"python3\",\n",
     "                            \"/opt/pytorch-mnist/mnist.py\",\n",
     "                            \"--epochs=1\",\n",
-    "                            \"--batch-size=64\",\n",
+    "                            \"--batch-size=16384\",\n",
     "                            \"--lr=${trialParameters.learningRate}\",\n",
     "                            \"--momentum=${trialParameters.momentum}\",\n",
     "                        ]\n",


### PR DESCRIPTION
Increase experiment's batch-size in order for the experiment to perform less training and thus complete earlier. 
The UAT's role is to confirm that the controller works, rather than run a full experiment training. (more details about debugging in the issue)

Fixes canonical/katib-operators#211

#### Testing

In order to test, deploy CKF `1.9/beta` to a Microk8s 1.29 and Juju 3.4. However, in order to perform a proper test of this you 'll need to rebase this branch (or cherry-pick the one commit) over the PR https://github.com/canonical/charmed-kubeflow-uats/pull/92 branch in order to have the new requirements as well. If done so, run
```
tox -e kubeflow-local -- --filter "katib"
``` 
