### PR TITLE
fix: refactor the `create_profile` fixture to ensure deletion

### DIFF
--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -15,13 +15,7 @@ from lightkube.generic_resource import (
     load_in_cluster_generic_resources,
 )
 from lightkube.types import CascadeType
-from utils import (
-    assert_namespace_active,
-    assert_profile_deleted,
-    delete_job,
-    fetch_job_logs,
-    wait_for_job,
-)
+from utils import assert_namespace_active, assert_profile_deleted, fetch_job_logs, wait_for_job
 
 log = logging.getLogger(__name__)
 
@@ -186,12 +180,6 @@ def test_kubeflow_workloads(
     finally:
         log.info("Fetching Job logs...")
         fetch_job_logs(JOB_NAME, NAMESPACE, TESTS_LOCAL_RUN)
-
-
-def teardown_module():
-    """Cleanup resources."""
-    log.info(f"Deleting Job {NAMESPACE}/{JOB_NAME}...")
-    delete_job(JOB_NAME, NAMESPACE)
 
 
 def proxy_context(request) -> Dict[str, str]:

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -14,6 +14,7 @@ from lightkube.generic_resource import (
     create_namespaced_resource,
     load_in_cluster_generic_resources,
 )
+from lightkube.types import CascadeType
 from utils import assert_namespace_active, delete_job, fetch_job_logs, wait_for_job
 
 log = logging.getLogger(__name__)
@@ -93,7 +94,7 @@ def create_profile(lightkube_client):
 
     # delete the Profile at the end of the module tests
     log.info(f"Deleting Profile {NAMESPACE}...")
-    lightkube_client.delete(PROFILE_RESOURCE, name=NAMESPACE)
+    lightkube_client.delete(PROFILE_RESOURCE, name=NAMESPACE, cascade=CascadeType.FOREGROUND)
 
 
 @pytest.fixture(scope="function")

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -15,7 +15,13 @@ from lightkube.generic_resource import (
     load_in_cluster_generic_resources,
 )
 from lightkube.types import CascadeType
-from utils import assert_namespace_active, delete_job, fetch_job_logs, wait_for_job
+from utils import (
+    assert_namespace_active,
+    assert_profile_deleted,
+    delete_job,
+    fetch_job_logs,
+    wait_for_job,
+)
 
 log = logging.getLogger(__name__)
 
@@ -95,6 +101,7 @@ def create_profile(lightkube_client):
     # delete the Profile at the end of the module tests
     log.info(f"Deleting Profile {NAMESPACE}...")
     lightkube_client.delete(PROFILE_RESOURCE, name=NAMESPACE, cascade=CascadeType.FOREGROUND)
+    assert_profile_deleted(lightkube_client, NAMESPACE, log)
 
 
 @pytest.fixture(scope="function")

--- a/driver/utils.py
+++ b/driver/utils.py
@@ -99,12 +99,6 @@ def fetch_job_logs(job_name, namespace, tests_local_run):
     subprocess.check_call(command)
 
 
-def delete_job(job_name, namespace, lightkube_client=None):
-    """Delete a Kubernetes Job."""
-    client = lightkube_client or Client(trust_env=False)
-    client.delete(Job, name=job_name, namespace=namespace)
-
-
 @tenacity.retry(
     wait=tenacity.wait_exponential(multiplier=2, min=1, max=10),
     stop=tenacity.stop_after_attempt(10),

--- a/driver/utils.py
+++ b/driver/utils.py
@@ -114,9 +114,12 @@ def assert_profile_deleted(client, profile_name, logger: logging.Logger):
     try:
         client.get(PROFILE_RESOURCE, profile_name)
     except ApiError as error:
-        logger.info(f"Unable to get Profile {profile_name} (status: {error.status.code})")
         if error.status.code != 404:
+            logger.info(f"Unable to get Profile {profile_name} (status: {error.status.code})")
             raise
-        deleted = True
+        else:
+            deleted = True
+    else:
+        logger.info(f"Waiting for Profile {profile_name} to be deleted..")
 
     assert deleted, f"Waited too long for Profile {profile_name} to be deleted!"

--- a/driver/utils.py
+++ b/driver/utils.py
@@ -118,7 +118,7 @@ def assert_profile_deleted(client, profile_name, logger: logging.Logger):
             raise
         else:
             deleted = True
-    else:
-        logger.info(f"Waiting for Profile {profile_name} to be deleted..")
+
+    logger.info(f"Waiting for Profile {profile_name} to be deleted..")
 
     assert deleted, f"Waited too long for Profile {profile_name} to be deleted!"

--- a/driver/utils.py
+++ b/driver/utils.py
@@ -6,10 +6,16 @@ import subprocess
 
 import tenacity
 from lightkube import ApiError, Client
+from lightkube.generic_resource import create_global_resource
 from lightkube.resources.batch_v1 import Job
 from lightkube.resources.core_v1 import Namespace
 
-from test_kubeflow_workloads import PROFILE_RESOURCE
+PROFILE_RESOURCE = create_global_resource(
+    group="kubeflow.org",
+    version="v1",
+    kind="profile",
+    plural="profiles",
+)
 
 log = logging.getLogger(__name__)
 

--- a/driver/utils.py
+++ b/driver/utils.py
@@ -9,7 +9,7 @@ from lightkube import ApiError, Client
 from lightkube.resources.batch_v1 import Job
 from lightkube.resources.core_v1 import Namespace
 
-from driver.test_kubeflow_workloads import PROFILE_RESOURCE
+from test_kubeflow_workloads import PROFILE_RESOURCE
 
 log = logging.getLogger(__name__)
 

--- a/driver/utils.py
+++ b/driver/utils.py
@@ -109,7 +109,6 @@ def assert_profile_deleted(client, profile_name, logger: logging.Logger):
 
     Retries multiple times to allow for the Profile to be deleted.
     """
-    logger.info(f"Waiting for Profile {profile_name} to be deleted.")
     deleted = False
     try:
         client.get(PROFILE_RESOURCE, profile_name)


### PR DESCRIPTION
Closes https://github.com/canonical/bundle-kubeflow/issues/951

## Summary
* In the `create_profile` fixture, set the `cascade` to foreground to ensure all the child resources for the profile are deleted
* Remove the `delete_job` function, this is no longer needed since we are deleting all of the profile's namespace 