### PR TITLE
fix: wait to allow PodDefaults to synced in Job's namespace before running tests

### DIFF
--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -14,7 +14,13 @@ from lightkube.generic_resource import (
     create_namespaced_resource,
     load_in_cluster_generic_resources,
 )
-from utils import assert_namespace_active, delete_job, fetch_job_logs, wait_for_job
+from utils import (
+    assert_namespace_active,
+    assert_poddefaults_created_in_namespace,
+    delete_job,
+    fetch_job_logs,
+    wait_for_job,
+)
 
 log = logging.getLogger(__name__)
 
@@ -46,6 +52,12 @@ PODDEFAULT_RESOURCE = create_namespaced_resource(
     plural="poddefaults",
 )
 PODDEFAULT_WITH_PROXY_PATH = Path("tests") / "proxy-poddefault.yaml.j2"
+
+REQUIRED_PODDEFAULTS_NAMES = [
+    "access-ml-pipeline",
+    "mlflow-server-access-minio",
+    "mlflow-server-minio",
+]
 
 
 @pytest.fixture(scope="session")
@@ -143,6 +155,9 @@ async def test_create_profile(lightkube_client, create_profile):
     assert profile_created, f"Profile {NAMESPACE} not found!"
 
     assert_namespace_active(lightkube_client, NAMESPACE)
+    assert_poddefaults_created_in_namespace(
+        lightkube_client, NAMESPACE, REQUIRED_PODDEFAULTS_NAMES
+    )
 
 
 def test_kubeflow_workloads(

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -18,9 +18,8 @@ from lightkube.generic_resource import (
 from lightkube.types import CascadeType
 from utils import (
     assert_namespace_active,
-    assert_profile_deleted,
     assert_poddefault_created_in_namespace,
-    delete_job,
+    assert_profile_deleted,
     fetch_job_logs,
     wait_for_job,
 )

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -165,11 +165,11 @@ async def test_create_profile(lightkube_client, create_profile):
     time.sleep(sleep_time_seconds)
 
     # Get PodDefaults in the test namespace
-    poddefaults_created_list = lightkube_client.list(PODDEFAULT_RESOURCE, namespace=NAMESPACE)
-    poddefaults_created_names = [pd.metadata.name for pd in poddefaults_created_list]
+    created_poddefaults_list = lightkube_client.list(PODDEFAULT_RESOURCE, namespace=NAMESPACE)
+    created_poddefaults_names = [pd.metadata.name for pd in created_poddefaults_list]
 
     # Print the names of PodDefaults in the test namespace
-    log.info(f"PodDefaults in {NAMESPACE} namespace are {poddefaults_created_names}.")
+    log.info(f"PodDefaults in {NAMESPACE} namespace are {created_poddefaults_names}.")
 
 
 def test_kubeflow_workloads(

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -14,13 +14,7 @@ from lightkube.generic_resource import (
     create_namespaced_resource,
     load_in_cluster_generic_resources,
 )
-from utils import (
-    assert_namespace_active,
-    assert_poddefaults_created_in_namespace,
-    delete_job,
-    fetch_job_logs,
-    wait_for_job,
-)
+from utils import assert_namespace_active, delete_job, fetch_job_logs, wait_for_job
 
 log = logging.getLogger(__name__)
 
@@ -52,12 +46,6 @@ PODDEFAULT_RESOURCE = create_namespaced_resource(
     plural="poddefaults",
 )
 PODDEFAULT_WITH_PROXY_PATH = Path("tests") / "proxy-poddefault.yaml.j2"
-
-REQUIRED_PODDEFAULTS_NAMES = [
-    "access-ml-pipeline",
-    "mlflow-server-access-minio",
-    "mlflow-server-minio",
-]
 
 
 @pytest.fixture(scope="session")
@@ -155,9 +143,6 @@ async def test_create_profile(lightkube_client, create_profile):
     assert profile_created, f"Profile {NAMESPACE} not found!"
 
     assert_namespace_active(lightkube_client, NAMESPACE)
-    assert_poddefaults_created_in_namespace(
-        lightkube_client, NAMESPACE, REQUIRED_PODDEFAULTS_NAMES
-    )
 
 
 def test_kubeflow_workloads(

--- a/driver/utils.py
+++ b/driver/utils.py
@@ -6,10 +6,18 @@ import subprocess
 
 import tenacity
 from lightkube import Client
+from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.batch_v1 import Job
 from lightkube.resources.core_v1 import Namespace
 
 log = logging.getLogger(__name__)
+
+PODDEFAULT_RESOURCE = create_namespaced_resource(
+    group="kubeflow.org",
+    version="v1alpha1",
+    kind="poddefault",
+    plural="poddefaults",
+)
 
 
 @tenacity.retry(
@@ -31,6 +39,27 @@ def assert_namespace_active(
 
     log.info(f"Waiting for namespace {namespace} to become 'Active': phase == {phase}")
     assert phase == "Active", f"Waited too long for namespace {namespace}!"
+
+
+@tenacity.retry(
+    wait=tenacity.wait_exponential(multiplier=2, min=1, max=10),
+    stop=tenacity.stop_after_attempt(15),
+    reraise=True,
+)
+def assert_poddefault_created_in_namespace(
+    client: Client,
+    name: str,
+    namespace: str,
+):
+    """Test that the given namespace contains the PodDefault required.
+
+    Retries multiple times to allow for the PodDefault to be synced to the namespace.
+    """
+
+    pod_default = client.get(PODDEFAULT_RESOURCE, name, namespace=namespace)
+    if pod_default is None:
+        log.info(f"Waiting for PodDefault {name} to be created in namespace {namespace}..")
+    assert pod_default is not None, f"Waited too long for PodDefault {name} to be created."
 
 
 def _log_before_sleep(retry_state):

--- a/driver/utils.py
+++ b/driver/utils.py
@@ -3,22 +3,13 @@
 
 import logging
 import subprocess
-from typing import List
 
 import tenacity
 from lightkube import Client
-from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.batch_v1 import Job
 from lightkube.resources.core_v1 import Namespace
 
 log = logging.getLogger(__name__)
-
-PODDEFAULT_RESOURCE = create_namespaced_resource(
-    group="kubeflow.org",
-    version="v1alpha1",
-    kind="poddefault",
-    plural="poddefaults",
-)
 
 
 @tenacity.retry(
@@ -40,25 +31,6 @@ def assert_namespace_active(
 
     log.info(f"Waiting for namespace {namespace} to become 'Active': phase == {phase}")
     assert phase == "Active", f"Waited too long for namespace {namespace}!"
-
-
-@tenacity.retry(
-    wait=tenacity.wait_exponential(multiplier=2, min=1, max=10),
-    stop=tenacity.stop_after_attempt(15),
-    reraise=True,
-)
-def assert_poddefaults_created_in_namespace(
-    client: Client,
-    namespace: str,
-    required_poddefaults_names: List[str],
-):
-    """Test that the given namespace contains all the PodDefaults required."""
-
-    for name in required_poddefaults_names:
-        pod_default = client.get(PODDEFAULT_RESOURCE, name, namespace=namespace)
-        if pod_default is None:
-            log.info(f"Waiting for PodDefault {name} to be created in namespace {namespace}..")
-        assert pod_default is not None, f"Waited too long for PodDefault {name} to be created."
 
 
 def _log_before_sleep(retry_state):

--- a/driver/utils.py
+++ b/driver/utils.py
@@ -55,6 +55,7 @@ def assert_poddefault_created_in_namespace(
 
     Retries multiple times to allow for the PodDefault to be synced to the namespace.
     """
+    pod_default = None
     try:
         pod_default = client.get(PODDEFAULT_RESOURCE, name, namespace=namespace)
     except ApiError:

--- a/driver/utils.py
+++ b/driver/utils.py
@@ -5,7 +5,7 @@ import logging
 import subprocess
 
 import tenacity
-from lightkube import Client
+from lightkube import ApiError, Client
 from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.batch_v1 import Job
 from lightkube.resources.core_v1 import Namespace
@@ -55,9 +55,9 @@ def assert_poddefault_created_in_namespace(
 
     Retries multiple times to allow for the PodDefault to be synced to the namespace.
     """
-
-    pod_default = client.get(PODDEFAULT_RESOURCE, name, namespace=namespace)
-    if pod_default is None:
+    try:
+        pod_default = client.get(PODDEFAULT_RESOURCE, name, namespace=namespace)
+    except ApiError:
         log.info(f"Waiting for PodDefault {name} to be created in namespace {namespace}..")
     assert pod_default is not None, f"Waited too long for PodDefault {name} to be created."
 


### PR DESCRIPTION
closes https://github.com/canonical/bundle-kubeflow/issues/1066

This is to overcome the race condition sometimes happening between:
1. the poddefaults being created in the test namespace
2. the job being created in the test namespace

The extra wait ensures that `1` happens before `2`

## Summary of changes
* Adds a `sleep` after creating the namespace to allow the resources to be synced to the namespace before the job runs
* Asserts that the list of poddefaults in the namespace is not empty
* Logs the names of poddefaults found in the namespace
* Asserts that the `access-ml-pipeline` poddefault exists in the namespace

## Results
<details>
<summary>UATs run logs from the PR</summary>
<br>

```
tox -e uats-remote -- --filter "not e2e"
uats-remote: commands[0]> pytest -vv --tb native /home/ubuntu/uat/driver/ -s --model kubeflow --filter 'not e2e'
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.8.20, pytest-7.4.3, pluggy-1.3.0 -- /home/ubuntu/uat/.tox/uats-remote/bin/python
cachedir: .tox/uats-remote/.pytest_cache
rootdir: /home/ubuntu/uat
configfile: pyproject.toml
plugins: anyio-4.0.0, asyncio-0.21.1, operator-0.31.0
asyncio: mode=strict
collected 2 items                                                                                                                                                                                          

driver/test_kubeflow_workloads.py::test_create_profile 
---------------------------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------------------------
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/apiextensions.k8s.io/v1/customresourcedefinitions "HTTP/1.1 200 OK"
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:83 Creating Profile test-kubeflow...
INFO     httpx:_client.py:1013 HTTP Request: POST https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1/profiles "HTTP/1.1 201 Created"
---------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1/profiles/test-kubeflow "HTTP/1.1 200 OK"
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/api/v1/namespaces/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:32 Waiting for namespace test-kubeflow to become 'Active': phase == Terminating
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/api/v1/namespaces/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:32 Waiting for namespace test-kubeflow to become 'Active': phase == Active
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:151 Sleeping for 40s to allow the creation of PodDefaults in test-kubeflow namespace..
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1alpha1/namespaces/test-kubeflow/poddefaults "HTTP/1.1 200 OK"
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:160 PodDefaults in test-kubeflow namespace are ['access-ml-pipeline', 'mlflow-server-access-minio', 'mlflow-server-minio'].
PASSED
driver/test_kubeflow_workloads.py::test_kubeflow_workloads 
---------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:169 Starting Kubernetes Job test-kubeflow/test-kubeflow to run notebook tests...
INFO     httpx:_client.py:1013 HTTP Request: POST https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs "HTTP/1.1 201 Created"
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == not ready)
INFO     utils:utils.py:40 Retrying in 2 seconds (attempts: 1)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 4 seconds (attempts: 2)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 8 seconds (attempts: 3)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 16 seconds (attempts: 4)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 5)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 6)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 7)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 8)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 9)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 10)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 11)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 12)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 13)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 14)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 15)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 16)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 17)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 18)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 19)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 20)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 21)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 22)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 23)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 24)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 25)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 26)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 27)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:76 Waiting for Job test-kubeflow/test-kubeflow to complete (status == active)
INFO     utils:utils.py:40 Retrying in 32 seconds (attempts: 28)
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"
INFO     utils:utils.py:69 Job test-kubeflow/test-kubeflow completed successfully!
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:196 Fetching Job logs...
##### git-sync initContainer logs #####
INFO: detected pid 1, running init handler
{"logger":"","ts":"2024-09-13 13:01:46.153796","caller":{"file":"main.go","line":722},"level":0,"msg":"starting up","pid":12,"uid":65533,"gid":65533,"home":"/tmp","flags":["--add-user=false","--change-permissions=0","--cookie-file=false","--depth=1","--exechook-backoff=3s","--exechook-timeout=30s","--git=git","--git-gc=always","--group-write=true","--help=false","--http-metrics=false","--http-pprof=false","--link=charmed-kubeflow-uats","--man=false","--max-failures=0","--max-sync-failures=0","--one-time=true","--password=REDACTED","--period=10s","--ref=204694d0a192202611ec171da54f858fea9b4c21","--repo=https://github.com/canonical/charmed-kubeflow-uats","--root=/tests","--ssh=false","--ssh-key-file=/etc/git-secret/ssh","--ssh-known-hosts=true","--ssh-known-hosts-file=/etc/git-secret/known_hosts","--stale-worktree-timeout=0s","--submodules=recursive","--sync-timeout=2m0s","--timeout=0","--v=-1","--verbose=0","--version=false","--wait=0","--webhook-backoff=3s","--webhook-method=POST","--webhook-success-status=200","--webhook-timeout=1s"]}
{"logger":"","ts":"2024-09-13 13:01:46.167813","caller":{"file":"main.go","line":1248},"level":0,"msg":"repo directory failed checks or was empty","path":"/tests"}
{"logger":"","ts":"2024-09-13 13:01:46.167938","caller":{"file":"main.go","line":1258},"level":0,"msg":"initializing repo directory","path":"/tests"}
{"logger":"","ts":"2024-09-13 13:01:46.514997","caller":{"file":"main.go","line":1797},"level":0,"msg":"update required","ref":"204694d0a192202611ec171da54f858fea9b4c21","local":"","remote":"204694d0a192202611ec171da54f858fea9b4c21","syncCount":0}
{"logger":"","ts":"2024-09-13 13:01:47.024882","caller":{"file":"main.go","line":1848},"level":0,"msg":"updated successfully","ref":"204694d0a192202611ec171da54f858fea9b4c21","remote":"204694d0a192202611ec171da54f858fea9b4c21","syncCount":1}
{"logger":"","ts":"2024-09-13 13:01:47.025076","caller":{"file":"main.go","line":1022},"level":0,"msg":"exiting after one sync","status":0}
##### test-kubeflow container logs #####
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7fed2a5bbc90>: Failed to establish a new connection: [Errno 101] Network is unreachable')': /simple/pytest/
WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7fed2a5daa10>: Failed to establish a new connection: [Errno 101] Network is unreachable')': /simple/pytest/
============================= test session starts ==============================
platform linux -- Python 3.11.9, pytest-8.3.3, pluggy-1.5.0 -- /opt/conda/bin/python3.11
cachedir: .pytest_cache
rootdir: /tests/.worktrees/204694d0a192202611ec171da54f858fea9b4c21/tests
configfile: pytest.ini
plugins: anyio-4.4.0
collecting ... collected 9 items / 1 deselected / 8 selected

test_notebooks.py::test_notebook[katib-integration] 
-------------------------------- live log call ---------------------------------
INFO     test_notebooks:test_notebooks.py:44 Running katib-integration.ipynb...
PASSED                                                                   [ 12%]
test_notebooks.py::test_notebook[kfp-v1-integration] 
-------------------------------- live log call ---------------------------------
INFO     test_notebooks:test_notebooks.py:44 Running kfp-v1-integration.ipynb...
PASSED                                                                   [ 25%]
test_notebooks.py::test_notebook[kfp-v2-integration] 
-------------------------------- live log call ---------------------------------
INFO     test_notebooks:test_notebooks.py:44 Running kfp-v2-integration.ipynb...
PASSED                                                                   [ 37%]
test_notebooks.py::test_notebook[kserve-integration] 
-------------------------------- live log call ---------------------------------
INFO     test_notebooks:test_notebooks.py:44 Running kserve-integration.ipynb...
PASSED                                                                   [ 50%]
test_notebooks.py::test_notebook[mlflow-integration] 
-------------------------------- live log call ---------------------------------
INFO     test_notebooks:test_notebooks.py:44 Running mlflow-integration.ipynb...
PASSED                                                                   [ 62%]
test_notebooks.py::test_notebook[mlflow-kserve] 
-------------------------------- live log call ---------------------------------
INFO     test_notebooks:test_notebooks.py:44 Running mlflow-kserve.ipynb...
PASSED                                                                   [ 75%]
test_notebooks.py::test_notebook[mlflow-minio-integration] 
-------------------------------- live log call ---------------------------------
INFO     test_notebooks:test_notebooks.py:44 Running mlflow-minio-integration.ipynb...
PASSED                                                                   [ 87%]
test_notebooks.py::test_notebook[training-integration] 
-------------------------------- live log call ---------------------------------
INFO     test_notebooks:test_notebooks.py:44 Running training-integration.ipynb...
PASSED                                                                   [100%]

================= 8 passed, 1 deselected in 775.42s (0:12:55) ==================
PASSED
-------------------------------------------------------------------------------------------- live log teardown ---------------------------------------------------------------------------------------------
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:96 Deleting Profile test-kubeflow...
INFO     httpx:_client.py:1013 HTTP Request: DELETE https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1/profiles/test-kubeflow "HTTP/1.1 200 OK"
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:202 Deleting Job test-kubeflow/test-kubeflow...
INFO     httpx:_client.py:1013 HTTP Request: DELETE https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/batch/v1/namespaces/test-kubeflow/jobs/test-kubeflow "HTTP/1.1 200 OK"


====================================================================================== 2 passed in 843.26s (0:14:03) =======================================================================================
  uats-remote: OK (844.42=setup[0.06]+cmd[844.36] seconds)
  congratulations :) (844.52 seconds)
```

</details>

Note: e2e test is skipped, it is failing due to https://github.com/canonical/bundle-kubeflow/issues/1067

See [AKS run using this branch](https://github.com/canonical/bundle-kubeflow/actions/runs/10899508960/job/30245067453)