### PR TITLE
fix: skip `test_kubeflow_workloads` when `test_create_profile` fails

### DIFF
--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -135,7 +135,7 @@ def create_poddefaults_on_proxy(request, lightkube_client):
 
 
 @pytest.mark.dependency()
-async def test_create_profile(ops_test, lightkube_client, create_profile):
+async def test_create_profile(lightkube_client, create_profile):
     """Test Profile creation.
 
     This test relies on the create_profile fixture, which handles the Profile creation and
@@ -176,7 +176,6 @@ async def test_create_profile(ops_test, lightkube_client, create_profile):
 
 @pytest.mark.dependency(depends=["test_create_profile"])
 def test_kubeflow_workloads(
-    ops_test,
     lightkube_client,
     pytest_cmd,
     tests_checked_out_commit,

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -134,8 +134,8 @@ def create_poddefaults_on_proxy(request, lightkube_client):
         lightkube_client.delete(PODDEFAULT_RESOURCE, name=poddefault_name, namespace=NAMESPACE)
 
 
-@pytest.mark.dependency()
-async def test_create_profile(lightkube_client, create_profile):
+@pytest.mark.abort_on_fail
+async def test_create_profile(ops_test, lightkube_client, create_profile):
     """Test Profile creation.
 
     This test relies on the create_profile fixture, which handles the Profile creation and
@@ -174,8 +174,8 @@ async def test_create_profile(lightkube_client, create_profile):
     log.info(f"PodDefaults in {NAMESPACE} namespace are {created_poddefaults_names}.")
 
 
-@pytest.mark.dependency(depends=["test_create_profile"])
 def test_kubeflow_workloads(
+    ops_test,
     lightkube_client,
     pytest_cmd,
     tests_checked_out_commit,

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -134,7 +134,7 @@ def create_poddefaults_on_proxy(request, lightkube_client):
         lightkube_client.delete(PODDEFAULT_RESOURCE, name=poddefault_name, namespace=NAMESPACE)
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.dependency()
 async def test_create_profile(ops_test, lightkube_client, create_profile):
     """Test Profile creation.
 
@@ -174,6 +174,7 @@ async def test_create_profile(ops_test, lightkube_client, create_profile):
     log.info(f"PodDefaults in {NAMESPACE} namespace are {created_poddefaults_names}.")
 
 
+@pytest.mark.dependency(depends=["test_create_profile"])
 def test_kubeflow_workloads(
     ops_test,
     lightkube_client,

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -135,7 +135,7 @@ def create_poddefaults_on_proxy(request, lightkube_client):
 
 
 @pytest.mark.abort_on_fail
-async def test_create_profile(lightkube_client, create_profile):
+async def test_create_profile(ops_test, lightkube_client, create_profile):
     """Test Profile creation.
 
     This test relies on the create_profile fixture, which handles the Profile creation and
@@ -175,7 +175,12 @@ async def test_create_profile(lightkube_client, create_profile):
 
 
 def test_kubeflow_workloads(
-    lightkube_client, pytest_cmd, tests_checked_out_commit, request, create_poddefaults_on_proxy
+    ops_test,
+    lightkube_client,
+    pytest_cmd,
+    tests_checked_out_commit,
+    request,
+    create_poddefaults_on_proxy,
 ):
     """Run a K8s Job to execute the notebook tests."""
     log.info(f"Starting Kubernetes Job {NAMESPACE}/{JOB_NAME} to run notebook tests...")

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -134,8 +134,8 @@ def create_poddefaults_on_proxy(request, lightkube_client):
         lightkube_client.delete(PODDEFAULT_RESOURCE, name=poddefault_name, namespace=NAMESPACE)
 
 
-@pytest.mark.abort_on_fail
-async def test_create_profile(ops_test, lightkube_client, create_profile):
+@pytest.mark.dependency()
+async def test_create_profile(lightkube_client, create_profile):
     """Test Profile creation.
 
     This test relies on the create_profile fixture, which handles the Profile creation and
@@ -174,8 +174,8 @@ async def test_create_profile(ops_test, lightkube_client, create_profile):
     log.info(f"PodDefaults in {NAMESPACE} namespace are {created_poddefaults_names}.")
 
 
+@pytest.mark.dependency(depends=["test_create_profile"])
 def test_kubeflow_workloads(
-    ops_test,
     lightkube_client,
     pytest_cmd,
     tests_checked_out_commit,

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 juju<4.0
 lightkube
 pytest
-pytest-dependency
+pytest-operator
 tenacity

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 juju<4.0
 lightkube
 pytest
-pytest-operator
+pytest-dependency
 tenacity

--- a/requirements.in
+++ b/requirements.in
@@ -2,4 +2,5 @@ juju<4.0
 lightkube
 pytest
 pytest-operator
+pytest-dependency
 tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -131,9 +131,12 @@ pytest==7.4.3
     # via
     #   -r requirements.in
     #   pytest-asyncio
+    #   pytest-dependency
     #   pytest-operator
 pytest-asyncio==0.21.1
     # via pytest-operator
+pytest-dependency==0.6.0
+    # via -r requirements.in
 pytest-operator==0.31.0
     # via -r requirements.in
 python-dateutil==2.8.2
@@ -198,3 +201,6 @@ websocket-client==1.6.4
     # via kubernetes
 websockets==8.1
     # via juju
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,6 @@
 #
 anyio==4.0.0
     # via httpx
-asttokens==2.4.1
-    # via stack-data
-backcall==0.2.0
-    # via ipython
 bcrypt==4.0.1
     # via paramiko
 cachetools==5.3.2
@@ -28,16 +24,10 @@ charset-normalizer==3.3.2
     # via requests
 cryptography==41.0.5
     # via paramiko
-decorator==5.1.1
-    # via
-    #   ipdb
-    #   ipython
 exceptiongroup==1.1.3
     # via
     #   anyio
     #   pytest
-executing==2.0.1
-    # via stack-data
 google-auth==2.23.4
     # via kubernetes
 h11==0.14.0
@@ -55,18 +45,8 @@ idna==3.4
     #   requests
 iniconfig==2.0.0
     # via pytest
-ipdb==0.13.13
-    # via pytest-operator
-ipython==8.12.3
-    # via ipdb
-jedi==0.19.1
-    # via ipython
-jinja2==3.1.2
-    # via pytest-operator
 juju==3.2.3.0
-    # via
-    #   -r requirements.in
-    #   pytest-operator
+    # via -r requirements.in
 kubernetes==28.1.0
     # via juju
 lightkube==0.15.0
@@ -75,10 +55,6 @@ lightkube-models==1.28.1.4
     # via lightkube
 macaroonbakery==1.3.1
     # via juju
-markupsafe==2.1.3
-    # via jinja2
-matplotlib-inline==0.1.6
-    # via ipython
 mypy-extensions==1.0.0
     # via typing-inspect
 oauthlib==3.2.2
@@ -89,22 +65,10 @@ packaging==23.2
     # via pytest
 paramiko==2.12.0
     # via juju
-parso==0.8.3
-    # via jedi
-pexpect==4.8.0
-    # via ipython
-pickleshare==0.7.5
-    # via ipython
 pluggy==1.3.0
     # via pytest
-prompt-toolkit==3.0.41
-    # via ipython
 protobuf==3.20.3
     # via macaroonbakery
-ptyprocess==0.7.0
-    # via pexpect
-pure-eval==0.2.2
-    # via stack-data
 pyasn1==0.5.0
     # via
     #   juju
@@ -114,8 +78,6 @@ pyasn1-modules==0.3.0
     # via google-auth
 pycparser==2.21
     # via cffi
-pygments==2.16.1
-    # via ipython
 pymacaroons==0.13.0
     # via macaroonbakery
 pynacl==1.5.0
@@ -130,11 +92,8 @@ pyrfc3339==1.1
 pytest==7.4.3
     # via
     #   -r requirements.in
-    #   pytest-asyncio
-    #   pytest-operator
-pytest-asyncio==0.21.1
-    # via pytest-operator
-pytest-operator==0.31.0
+    #   pytest-dependency
+pytest-dependency==0.6.0
     # via -r requirements.in
 python-dateutil==2.8.2
     # via kubernetes
@@ -145,7 +104,6 @@ pyyaml==6.0.1
     #   juju
     #   kubernetes
     #   lightkube
-    #   pytest-operator
 requests==2.31.0
     # via
     #   hvac
@@ -158,7 +116,6 @@ rsa==4.9
     # via google-auth
 six==1.16.0
     # via
-    #   asttokens
     #   kubernetes
     #   macaroonbakery
     #   paramiko
@@ -168,33 +125,24 @@ sniffio==1.3.0
     # via
     #   anyio
     #   httpx
-stack-data==0.6.3
-    # via ipython
 tenacity==8.2.3
     # via -r requirements.in
 tomli==2.0.1
-    # via
-    #   ipdb
-    #   pytest
+    # via pytest
 toposort==1.10
     # via juju
-traitlets==5.13.0
-    # via
-    #   ipython
-    #   matplotlib-inline
 typing-extensions==4.8.0
-    # via
-    #   ipython
-    #   typing-inspect
+    # via typing-inspect
 typing-inspect==0.9.0
     # via juju
 urllib3==1.26.18
     # via
     #   kubernetes
     #   requests
-wcwidth==0.2.10
-    # via prompt-toolkit
 websocket-client==1.6.4
     # via kubernetes
 websockets==8.1
     # via juju
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,10 @@
 #
 anyio==4.0.0
     # via httpx
+asttokens==2.4.1
+    # via stack-data
+backcall==0.2.0
+    # via ipython
 bcrypt==4.0.1
     # via paramiko
 cachetools==5.3.2
@@ -24,10 +28,16 @@ charset-normalizer==3.3.2
     # via requests
 cryptography==41.0.5
     # via paramiko
+decorator==5.1.1
+    # via
+    #   ipdb
+    #   ipython
 exceptiongroup==1.1.3
     # via
     #   anyio
     #   pytest
+executing==2.0.1
+    # via stack-data
 google-auth==2.23.4
     # via kubernetes
 h11==0.14.0
@@ -45,8 +55,18 @@ idna==3.4
     #   requests
 iniconfig==2.0.0
     # via pytest
+ipdb==0.13.13
+    # via pytest-operator
+ipython==8.12.3
+    # via ipdb
+jedi==0.19.1
+    # via ipython
+jinja2==3.1.2
+    # via pytest-operator
 juju==3.2.3.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   pytest-operator
 kubernetes==28.1.0
     # via juju
 lightkube==0.15.0
@@ -55,6 +75,10 @@ lightkube-models==1.28.1.4
     # via lightkube
 macaroonbakery==1.3.1
     # via juju
+markupsafe==2.1.3
+    # via jinja2
+matplotlib-inline==0.1.6
+    # via ipython
 mypy-extensions==1.0.0
     # via typing-inspect
 oauthlib==3.2.2
@@ -65,10 +89,22 @@ packaging==23.2
     # via pytest
 paramiko==2.12.0
     # via juju
+parso==0.8.3
+    # via jedi
+pexpect==4.8.0
+    # via ipython
+pickleshare==0.7.5
+    # via ipython
 pluggy==1.3.0
     # via pytest
+prompt-toolkit==3.0.41
+    # via ipython
 protobuf==3.20.3
     # via macaroonbakery
+ptyprocess==0.7.0
+    # via pexpect
+pure-eval==0.2.2
+    # via stack-data
 pyasn1==0.5.0
     # via
     #   juju
@@ -78,6 +114,8 @@ pyasn1-modules==0.3.0
     # via google-auth
 pycparser==2.21
     # via cffi
+pygments==2.16.1
+    # via ipython
 pymacaroons==0.13.0
     # via macaroonbakery
 pynacl==1.5.0
@@ -92,8 +130,11 @@ pyrfc3339==1.1
 pytest==7.4.3
     # via
     #   -r requirements.in
-    #   pytest-dependency
-pytest-dependency==0.6.0
+    #   pytest-asyncio
+    #   pytest-operator
+pytest-asyncio==0.21.1
+    # via pytest-operator
+pytest-operator==0.31.0
     # via -r requirements.in
 python-dateutil==2.8.2
     # via kubernetes
@@ -104,6 +145,7 @@ pyyaml==6.0.1
     #   juju
     #   kubernetes
     #   lightkube
+    #   pytest-operator
 requests==2.31.0
     # via
     #   hvac
@@ -116,6 +158,7 @@ rsa==4.9
     # via google-auth
 six==1.16.0
     # via
+    #   asttokens
     #   kubernetes
     #   macaroonbakery
     #   paramiko
@@ -125,24 +168,33 @@ sniffio==1.3.0
     # via
     #   anyio
     #   httpx
+stack-data==0.6.3
+    # via ipython
 tenacity==8.2.3
     # via -r requirements.in
 tomli==2.0.1
-    # via pytest
+    # via
+    #   ipdb
+    #   pytest
 toposort==1.10
     # via juju
+traitlets==5.13.0
+    # via
+    #   ipython
+    #   matplotlib-inline
 typing-extensions==4.8.0
-    # via typing-inspect
+    # via
+    #   ipython
+    #   typing-inspect
 typing-inspect==0.9.0
     # via juju
 urllib3==1.26.18
     # via
     #   kubernetes
     #   requests
+wcwidth==0.2.10
+    # via prompt-toolkit
 websocket-client==1.6.4
     # via kubernetes
 websockets==8.1
     # via juju
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
closes #121 

## Summary
The PR uses [`pytest-dependency` plugin](https://pytest-dependency.readthedocs.io/en/latest/index.html) to define the dependencies between the tests. 

See https://github.com/canonical/charmed-kubeflow-uats/issues/121#issuecomment-2358217050 on why we went against using the `pytest-operator` marker `@pytest.mark.abort_on_fail`.

## Testing
to make the `test_create_profile` fail, I  edited [L154](https://github.com/canonical/charmed-kubeflow-uats/blob/main/driver/test_kubeflow_workloads.py#L154) to be `assert profile_created==False, f"Profile {NAMESPACE} not found!"`

The result logs from running the UATs:
```
tox -e uats-remote -- --filter "kfp-v2"
uats-remote: commands[0]> pytest -vv --tb native /home/ubuntu/uat/driver/ -s --model kubeflow --filter kfp-v2
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.8.20, pytest-7.4.3, pluggy-1.3.0 -- /home/ubuntu/uat/.tox/uats-remote/bin/python
cachedir: .tox/uats-remote/.pytest_cache
rootdir: /home/ubuntu/uat
configfile: pyproject.toml
plugins: anyio-4.0.0, dependency-0.6.0, asyncio-0.21.1, operator-0.31.0
asyncio: mode=strict
collected 2 items                                                                                                                                                                                          

driver/test_kubeflow_workloads.py::test_create_profile 
---------------------------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------------------------
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/apiextensions.k8s.io/v1/customresourcedefinitions "HTTP/1.1 200 OK"
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:92 Creating Profile test-kubeflow...
INFO     httpx:_client.py:1013 HTTP Request: POST https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1/profiles "HTTP/1.1 201 Created"
---------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1/profiles/test-kubeflow "HTTP/1.1 200 OK"
FAILED
driver/test_kubeflow_workloads.py::test_kubeflow_workloads 
---------------------------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------------------------
INFO     pytest_dependency:pytest_dependency.py:100 skip test_kubeflow_workloads because it depends on test_create_profile
SKIPPED (test_kubeflow_workloads depends on test_create_profile)
-------------------------------------------------------------------------------------------- live log teardown ---------------------------------------------------------------------------------------------
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:105 Deleting Profile test-kubeflow...
INFO     httpx:_client.py:1013 HTTP Request: DELETE https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1/profiles/test-kubeflow?propagationPolicy=Foreground "HTTP/1.1 200 OK"
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1/profiles/test-kubeflow "HTTP/1.1 200 OK"
INFO     test_kubeflow_workloads:utils.py:151 Waiting for Profile test-kubeflow to be deleted..
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1/profiles/test-kubeflow "HTTP/1.1 200 OK"
INFO     test_kubeflow_workloads:utils.py:151 Waiting for Profile test-kubeflow to be deleted..
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1/profiles/test-kubeflow "HTTP/1.1 200 OK"
INFO     test_kubeflow_workloads:utils.py:151 Waiting for Profile test-kubeflow to be deleted..
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1/profiles/test-kubeflow "HTTP/1.1 404 Not Found"
INFO     test_kubeflow_workloads:utils.py:151 Waiting for Profile test-kubeflow to be deleted..


================================================================================================= FAILURES =================================================================================================
___________________________________________________________________________________________ test_create_profile ____________________________________________________________________________________________
Traceback (most recent call last):
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/_pytest/runner.py", line 341, in from_call
    result: Optional[TResult] = func()
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/_pytest/runner.py", line 262, in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/pluggy/_hooks.py", line 493, in __call__
    return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/pluggy/_manager.py", line 115, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/pluggy/_callers.py", line 152, in _multicall
    return outcome.get_result()
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/pluggy/_result.py", line 114, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/pluggy/_callers.py", line 77, in _multicall
    res = hook_impl.function(*args)
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/_pytest/runner.py", line 177, in pytest_runtest_call
    raise e
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/_pytest/runner.py", line 169, in pytest_runtest_call
    item.runtest()
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/_pytest/python.py", line 1792, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/pluggy/_hooks.py", line 493, in __call__
    return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/pluggy/_manager.py", line 115, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/pluggy/_callers.py", line 152, in _multicall
    return outcome.get_result()
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/pluggy/_result.py", line 114, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/pluggy/_callers.py", line 77, in _multicall
    res = hook_impl.function(*args)
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/home/ubuntu/uat/.tox/uats-remote/lib/python3.8/site-packages/pytest_asyncio/plugin.py", line 532, in inner
    _loop.run_until_complete(task)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/ubuntu/uat/driver/test_kubeflow_workloads.py", line 154, in test_create_profile
    assert profile_created==False, f"Profile {NAMESPACE} not found!"
AssertionError: Profile test-kubeflow not found!
assert {'apiVersion': 'kubeflow.org/v1', 'kind': 'Profile', 'metadata': {'creationTimestamp': '2024-09-18T11:15:57Z', 'generation': 1, 'managedFields': [{'apiVersion': 'kubeflow.org/v1', 'fieldsType': 'FieldsV1', 'fieldsV1': {'f:spec': {'.': {}, 'f:owner': {'.': {}, 'f:kind': {}, 'f:name': {}}}}, 'manager': 'python-httpx', 'operation': 'Update', 'time': '2024-09-18T11:15:57Z'}], 'name': 'test-kubeflow', 'resourceVersion': '7093747', 'uid': '0f0db999-44a8-4d6a-81bc-a029e2de070e'}, 'spec': {'owner': {'kind': 'User', 'name': 'test-kubeflow@email.com'}}} == False
-------------------------------------------------------------------------------------------- Captured log setup --------------------------------------------------------------------------------------------
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/apiextensions.k8s.io/v1/customresourcedefinitions "HTTP/1.1 200 OK"
INFO     test_kubeflow_workloads:test_kubeflow_workloads.py:92 Creating Profile test-kubeflow...
INFO     httpx:_client.py:1013 HTTP Request: POST https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1/profiles "HTTP/1.1 201 Created"
-------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------
INFO     httpx:_client.py:1013 HTTP Request: GET https://kubeflow-4b5f4so8.hcp.westeurope.azmk8s.io/apis/kubeflow.org/v1/profiles/test-kubeflow "HTTP/1.1 200 OK"
========================================================================================= short test summary info ==========================================================================================
FAILED driver/test_kubeflow_workloads.py::test_create_profile - AssertionError: Profile test-kubeflow not found!
====================================================================================== 1 failed, 1 skipped in 15.01s =======================================================================================
uats-remote: exit 1 (15.99 seconds) /home/ubuntu/uat> pytest -vv --tb native /home/ubuntu/uat/driver/ -s --model kubeflow --filter kfp-v2 pid=192909
  uats-remote: FAIL code 1 (16.05=setup[0.05]+cmd[15.99] seconds)
  evaluation failed :( (16.15 seconds)
```
AKS [run](https://github.com/canonical/bundle-kubeflow/actions/runs/10921250737) using this branch (note this is without making the `test_create_profile` fail, the above logs showcase that situation)