### PR TITLE
Update requirements for kfp 2.10.1

### DIFF
--- a/tests/notebooks/kfp_v2/requirements.txt
+++ b/tests/notebooks/kfp_v2/requirements.txt
@@ -4,25 +4,25 @@
 #
 #    pip-compile requirements.in
 #
-cachetools==5.3.3
+cachetools==5.5.0
     # via google-auth
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   kfp-server-api
     #   kubernetes
     #   requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via kfp
 docstring-parser==0.16
     # via kfp
-google-api-core==2.19.1
+google-api-core==2.23.0
     # via
     #   google-cloud-core
     #   google-cloud-storage
     #   kfp
-google-auth==2.32.0
+google-auth==2.36.0
     # via
     #   google-api-core
     #   google-cloud-core
@@ -31,48 +31,50 @@ google-auth==2.32.0
     #   kubernetes
 google-cloud-core==2.4.1
     # via google-cloud-storage
-google-cloud-storage==2.17.0
+google-cloud-storage==2.18.2
     # via kfp
-google-crc32c==1.5.0
+google-crc32c==1.6.0
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.7.1
+google-resumable-media==2.7.2
     # via google-cloud-storage
-googleapis-common-protos==1.63.2
+googleapis-common-protos==1.66.0
     # via google-api-core
-idna==3.7
+idna==3.10
     # via requests
-kfp==2.8.0
+kfp==2.10.1
     # via -r requirements.in
-kfp-pipeline-spec==0.3.0
+kfp-pipeline-spec==0.5.0
     # via kfp
-kfp-server-api==2.0.5
+kfp-server-api==2.3.0
     # via kfp
-kubernetes==26.1.0
+kubernetes==30.1.0
     # via kfp
 oauthlib==3.2.2
-    # via requests-oauthlib
-proto-plus==1.24.0
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+proto-plus==1.25.0
     # via google-api-core
-protobuf==4.25.3
+protobuf==4.25.5
     # via
     #   google-api-core
     #   googleapis-common-protos
     #   kfp
     #   kfp-pipeline-spec
     #   proto-plus
-pyasn1==0.6.0
+pyasn1==0.6.1
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.0
+pyasn1-modules==0.4.1
     # via google-auth
 python-dateutil==2.9.0.post0
     # via
     #   kfp-server-api
     #   kubernetes
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   kfp
     #   kubernetes
@@ -96,9 +98,9 @@ six==1.16.0
     #   python-dateutil
 tabulate==0.9.0
     # via kfp
-tenacity==8.5.0
+tenacity==9.0.0
     # via -r requirements.in
-urllib3==1.26.19
+urllib3==1.26.20
     # via
     #   kfp
     #   kfp-server-api
@@ -106,6 +108,3 @@ urllib3==1.26.19
     #   requests
 websocket-client==1.8.0
     # via kubernetes
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
Partialy solves: https://github.com/canonical/kfp-operators/issues/594 

**NOTE:** This PR needs to be first tested when all changes of for kfp upgrade to 2.3.x. Run the UATs with all changes to make sure it works. 

Please read this https://github.com/canonical/kfp-operators/issues/594#issuecomment-2503750491. We are not able to update kfp in all notebooks for now.