### PR TITLE
fix: wait to allow PodDefaults to synced in Job's namespace before running tests (#120)

### DIFF
--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -4,12 +4,23 @@
 import logging
 import os
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
 from lightkube import ApiError, Client, codecs
-from lightkube.generic_resource import create_global_resource, load_in_cluster_generic_resources
-from utils import assert_namespace_active, delete_job, fetch_job_logs, wait_for_job
+from lightkube.generic_resource import (
+    create_global_resource,
+    create_namespaced_resource,
+    load_in_cluster_generic_resources,
+)
+from utils import (
+    assert_namespace_active,
+    assert_poddefault_created_in_namespace,
+    delete_job,
+    fetch_job_logs,
+    wait_for_job,
+)
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +44,15 @@ PROFILE_RESOURCE = create_global_resource(
 JOB_NAME = "test-kubeflow"
 
 PYTEST_CMD_BASE = "pytest"
+
+PODDEFAULT_RESOURCE = create_namespaced_resource(
+    group="kubeflow.org",
+    version="v1alpha1",
+    kind="poddefault",
+    plural="poddefaults",
+)
+
+KFP_PODDEFAULT_NAME = "access-ml-pipeline"
 
 
 @pytest.fixture(scope="session")
@@ -103,6 +123,24 @@ async def test_create_profile(lightkube_client, create_profile):
     assert profile_created, f"Profile {NAMESPACE} not found!"
 
     assert_namespace_active(lightkube_client, NAMESPACE)
+
+    # Wait until KFP PodDefault is created in the namespace
+    assert_poddefault_created_in_namespace(lightkube_client, KFP_PODDEFAULT_NAME, NAMESPACE)
+
+    # Sync of other PodDefaults to the namespace can take up to 10 seconds
+    # Wait here is necessary to allow the creation of PodDefaults before Job is created
+    sleep_time_seconds = 10
+    log.info(
+        f"Sleeping for {sleep_time_seconds}s to allow the creation of PodDefaults in {NAMESPACE} namespace.."
+    )
+    time.sleep(sleep_time_seconds)
+
+    # Get PodDefaults in the test namespace
+    created_poddefaults_list = lightkube_client.list(PODDEFAULT_RESOURCE, namespace=NAMESPACE)
+    created_poddefaults_names = [pd.metadata.name for pd in created_poddefaults_list]
+
+    # Print the names of PodDefaults in the test namespace
+    log.info(f"PodDefaults in {NAMESPACE} namespace are {created_poddefaults_names}.")
 
 
 def test_kubeflow_workloads(lightkube_client, pytest_cmd, tests_checked_out_commit):


### PR DESCRIPTION
Backports https://github.com/canonical/charmed-kubeflow-uats/pull/120 to `track/1.8`
Part of fixing https://github.com/canonical/charmed-kubeflow-uats/issues/142

**Summary**
* fix: check PodDefaults in namespace before running tests
* sleep until resources are synced to namespace
* assert on kfp poddefault
* use tenacity to wait for kfp poddefault
* log on apierror to get poddefault