### PR TITLE
fix: skip `test_kubeflow_workloads` when `test_create_profile` fails (#122)

### DIFF
--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -83,7 +83,7 @@ def create_profile(lightkube_client):
     lightkube_client.delete(PROFILE_RESOURCE, name=NAMESPACE)
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.dependency()
 async def test_create_profile(lightkube_client, create_profile):
     """Test Profile creation.
 
@@ -105,7 +105,12 @@ async def test_create_profile(lightkube_client, create_profile):
     assert_namespace_active(lightkube_client, NAMESPACE)
 
 
-def test_kubeflow_workloads(lightkube_client, pytest_cmd, tests_checked_out_commit):
+@pytest.mark.dependency(depends=["test_create_profile"])
+def test_kubeflow_workloads(
+    lightkube_client,
+    pytest_cmd,
+    tests_checked_out_commit,
+):
     """Run a K8s Job to execute the notebook tests."""
     log.info(f"Starting Kubernetes Job {NAMESPACE}/{JOB_NAME} to run notebook tests...")
     resources = list(

--- a/requirements.in
+++ b/requirements.in
@@ -2,4 +2,5 @@ juju<4.0
 lightkube
 pytest
 pytest-operator
+pytest-dependency
 tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -131,9 +131,12 @@ pytest==7.4.3
     # via
     #   -r requirements.in
     #   pytest-asyncio
+    #   pytest-dependency
     #   pytest-operator
 pytest-asyncio==0.21.1
     # via pytest-operator
+pytest-dependency==0.6.0
+    # via -r requirements.in
 pytest-operator==0.31.0
     # via -r requirements.in
 python-dateutil==2.8.2
@@ -198,3 +201,6 @@ websocket-client==1.6.4
     # via kubernetes
 websockets==8.1
     # via juju
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
Backports https://github.com/canonical/charmed-kubeflow-uats/pull/120 to `track/1.8`
Part of fixing https://github.com/canonical/charmed-kubeflow-uats/issues/142

**Summary**
The PR uses [pytest-dependency plugin](https://pytest-dependency.readthedocs.io/en/latest/index.html) to define the dependencies between the tests.