### PR TITLE
feat: Add bundle url as input and use latest as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ This simulates the behaviour of running `pytest -k "some filter"` directly on th
 You can read more about the options provided by Pytest in the corresponding section of the
 [documentation](https://docs.pytest.org/en/7.4.x/reference/reference.html#command-line-flags).
 
-#### Specify a different bundle url
+#### Specify a different bundle
 
 To provide a different bundle to be used to check that the deployment has the correct channel version, 
 use the `--bundle` flag, e.g.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ found in the [Run the tests](#run-the-tests) section.
       * [Using a remote commit](#run-tests-from-a-remote-commit)
       * [Using a local copy](#run-tests-from-local-copy)
       * [A subset of UATs](#run-a-subset-of-uats)
-      * [Specify a different bundle url](#specify-a-different-bundle-url)
+      * [Specify a different bundle](#specify-a-different-bundle)
       * [Kubeflow UATs](#run-kubeflow-uats)
       * [MLflow UATs](#run-mlflow-uats)
    * [NVIDIA GPU UAT](#nvidia-gpu-uat)

--- a/README.md
+++ b/README.md
@@ -65,8 +65,14 @@ As mentioned before, when it comes to running the tests, you've got 2 options:
 * Running the tests on an existing cluster using the `driver` along with the provided automation
 
 NOTE: Depending on the version of Charmed Kubeflow you want to test, make sure to checkout to the appropriate branch with `git checkout`:
+- Charmed Kubeflow 1.9 -> `track/1.9`
 - Charmed Kubeflow 1.8 -> `track/1.8`
 - Charmed Kubeflow 1.7 -> `track/1.7`
+
+As part of the tests, the UATs checks that the version of the applications are the ones expected for the various tracks. The different branches
+above points to a different bundle URL from the [bundle-kubeflow](https://github.com/canonical/bundle-kubeflow) repository to compare the 
+channel in the deployment being tested. `main` branch also provides ability to specify the URL of the bundle to be used to checking by providing
+the `--bundle-url` argument for the tox entrypoints.
 
 ### Running inside a Notebook
 
@@ -147,6 +153,17 @@ tox -e uats-local -- --filter "kfp or katib"
 This simulates the behaviour of running `pytest -k "some filter"` directly on the test suite.
 You can read more about the options provided by Pytest in the corresponding section of the
 [documentation](https://docs.pytest.org/en/7.4.x/reference/reference.html#command-line-flags).
+
+#### Specify a different bundle url
+
+To provide a different bundle URL to be used to check that the deployment has the correct channel version, 
+use the `--bundle-url` flag, e.g.
+
+```bash
+tox -e uats-remote -- --bundle-url <my-bundle-url>
+```
+
+This flag is currently only provided on main branches. 
 
 #### Run Kubeflow UATs
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ NOTE: Depending on the version of Charmed Kubeflow you want to test, make sure t
 `main` branch is generally used for testing against the `latest/edge` track of the bundle.   
 
 As part of the tests, the UATs checks that the version of the applications are the ones expected for the various tracks. The different branches
-above point to a different bundle URL from the [bundle-kubeflow](https://github.com/canonical/bundle-kubeflow) repository to compare the 
-channels in the deployment being tested. `main` branch also provides ability to specify the URL of the bundle to be used for checking by providing
-the `--bundle-url` argument for the tox entrypoints.
+above point to a different bundle from the [bundle-kubeflow](https://github.com/canonical/bundle-kubeflow) repository to compare the 
+channels in the deployment being tested. `main` branch also provides ability to specify the of the bundle to be used for checking by providing
+the `--bundle` argument for the tox entrypoints.
 
 ### Running inside a Notebook
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ NOTE: Depending on the version of Charmed Kubeflow you want to test, make sure t
 - Charmed Kubeflow 1.9 -> `track/1.9`
 - Charmed Kubeflow 1.8 -> `track/1.8`
 - Charmed Kubeflow 1.7 -> `track/1.7`
+
 `main` branch is generally used for testing against the `latest/edge` track of the bundle.   
 
 As part of the tests, the UATs checks that the version of the applications are the ones expected for the various tracks. The different branches

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ You can read more about the options provided by Pytest in the corresponding sect
 #### Specify a different bundle url
 
 To provide a different bundle to be used to check that the deployment has the correct channel version, 
-use the `--bundle-url` flag, e.g.
+use the `--bundle` flag, e.g.
 
 ```bash
 tox -e uats-remote -- --bundle <my-bundle>

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ NOTE: Depending on the version of Charmed Kubeflow you want to test, make sure t
 - Charmed Kubeflow 1.7 -> `track/1.7`
 
 As part of the tests, the UATs checks that the version of the applications are the ones expected for the various tracks. The different branches
-above points to a different bundle URL from the [bundle-kubeflow](https://github.com/canonical/bundle-kubeflow) repository to compare the 
-channel in the deployment being tested. `main` branch also provides ability to specify the URL of the bundle to be used to checking by providing
+above point to a different bundle URL from the [bundle-kubeflow](https://github.com/canonical/bundle-kubeflow) repository to compare the 
+channels in the deployment being tested. `main` branch also provides ability to specify the URL of the bundle to be used for checking by providing
 the `--bundle-url` argument for the tox entrypoints.
 
 ### Running inside a Notebook

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ found in the [Run the tests](#run-the-tests) section.
       * [Using a remote commit](#run-tests-from-a-remote-commit)
       * [Using a local copy](#run-tests-from-local-copy)
       * [A subset of UATs](#run-a-subset-of-uats)
+      * [Specify a different bundle url](#specify-a-different-bundle-url)
       * [Kubeflow UATs](#run-kubeflow-uats)
       * [MLflow UATs](#run-mlflow-uats)
    * [NVIDIA GPU UAT](#nvidia-gpu-uat)
@@ -68,6 +69,7 @@ NOTE: Depending on the version of Charmed Kubeflow you want to test, make sure t
 - Charmed Kubeflow 1.9 -> `track/1.9`
 - Charmed Kubeflow 1.8 -> `track/1.8`
 - Charmed Kubeflow 1.7 -> `track/1.7`
+`main` branch is generally used for testing against the `latest/edge` track of the bundle.   
 
 As part of the tests, the UATs checks that the version of the applications are the ones expected for the various tracks. The different branches
 above point to a different bundle URL from the [bundle-kubeflow](https://github.com/canonical/bundle-kubeflow) repository to compare the 
@@ -156,14 +158,16 @@ You can read more about the options provided by Pytest in the corresponding sect
 
 #### Specify a different bundle url
 
-To provide a different bundle URL to be used to check that the deployment has the correct channel version, 
+To provide a different bundle to be used to check that the deployment has the correct channel version, 
 use the `--bundle-url` flag, e.g.
 
 ```bash
-tox -e uats-remote -- --bundle-url <my-bundle-url>
+tox -e uats-remote -- --bundle <my-bundle>
 ```
 
-This flag is currently only provided on main branches. 
+The `<my-bundle>` can be replaced by either a URL, e.g. `http://...`, or a local file, `file:/path/to/file`. Note that the local file path must be accessible when running the tests. 
+
+This flag is currently only provided on main branch and tracks 1.9+. 
 
 #### Run Kubeflow UATs
 

--- a/driver/conftest.py
+++ b/driver/conftest.py
@@ -61,7 +61,7 @@ def pytest_addoption(parser: Parser):
         help="Provide the name of the namespace/juju model where kubeflow is deployed.",
     )
     parser.addoption(
-        "--bundle-url",
+        "--bundle",
         default=BUNDLE_URL,
-        help="Provide the URL for the bundle to be used during the check. If empty the check is skipped",
+        help="Provide the bundle to be used during the check. You can use a URL, e.g. http://..., or a local file, file:/path/to/file. If empty, the check is skipped",
     )

--- a/driver/conftest.py
+++ b/driver/conftest.py
@@ -5,6 +5,7 @@ from _pytest.config.argparsing import Parser
 
 BUNDLE_URL = "https://raw.githubusercontent.com/canonical/bundle-kubeflow/refs/heads/main/releases/latest/edge/bundle.yaml"
 
+
 def pytest_addoption(parser: Parser):
     """Add pytest options.
 

--- a/driver/conftest.py
+++ b/driver/conftest.py
@@ -3,6 +3,7 @@
 
 from _pytest.config.argparsing import Parser
 
+BUNDLE_URL = "https://raw.githubusercontent.com/canonical/bundle-kubeflow/refs/heads/main/releases/latest/edge/bundle.yaml"
 
 def pytest_addoption(parser: Parser):
     """Add pytest options.
@@ -57,4 +58,9 @@ def pytest_addoption(parser: Parser):
         "--kubeflow-model",
         default="kubeflow",
         help="Provide the name of the namespace/juju model where kubeflow is deployed.",
+    )
+    parser.addoption(
+        "--bundle-url",
+        default=BUNDLE_URL,
+        help="Provide the URL for the bundle to be used during the check. If empty the check is skipped",
     )

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -62,12 +62,12 @@ PODDEFAULT_WITH_TOLERATION_PATH = Path("assets") / "gpu-toleration-poddefault.ya
 
 KFP_PODDEFAULT_NAME = "access-ml-pipeline"
 
-BUNDLE_URL = "https://raw.githubusercontent.com/canonical/bundle-kubeflow/refs/heads/main/releases/1.9/stable/bundle.yaml"
-
 
 @pytest.fixture(scope="module")
-def charm_list():
-    if not (response := requests.get(BUNDLE_URL)) or (response.status_code != 200):
+def charm_list(request):
+    url = request.config.getoption("--bundle-url")
+
+    if not url or not (response := requests.get(url)) or (response.status_code != 200):
         return {}
 
     bundle = yaml.safe_load(response.content.decode("utf-8"))

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -198,7 +198,7 @@ async def test_bundle_correctness(ops_test, kubeflow_model, charm_list):
         app_channel = status["applications"][name]["charm-channel"]
         assert re.compile(channel_regex).match(
             app_channel
-        ), f"Failed correctness check. Expected: {channel_regex} Found: {app_channel}"
+        ), f"Failed bundle correctness check. Expected: {channel_regex} Found: {app_channel}"
 
     # Check that everything is active/idle
     await ops_test.model.wait_for_idle(

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -65,7 +65,7 @@ KFP_PODDEFAULT_NAME = "access-ml-pipeline"
 
 @pytest.fixture(scope="module")
 def charm_list(request):
-    url = request.config.getoption("--bundle-url")
+    url = request.config.getoption("--bundle")
 
     if not url:
         return {}
@@ -186,6 +186,13 @@ def create_poddefault_on_toleration(request, lightkube_client):
 
 @pytest.mark.abort_on_fail
 async def test_bundle_correctness(ops_test, kubeflow_model, charm_list):
+    """Test that the correct bundle is selected.
+
+    Tests are specific to each Charmed Kubeflow version release. This test makes sure that
+    the correct version of the bundle, consistent with the tests, is specified. In order to
+    check the correctness, we use a YAML bundle that is pulled from the correct URL in the
+    bundle-kubeflow repository. This value can be overridden using the `--bundle` argument. 
+    """
 
     if not charm_list:
         pytest.skip("charm_list empty. Cannot test bundle correctness")

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -186,7 +186,7 @@ async def test_bundle_correctness(ops_test, kubeflow_model, charm_list):
         app_channel = status["applications"][name]["charm-channel"]
         assert re.compile(channel_regex).match(
             app_channel
-        ), f"failing correctness check. Expected: {channel_regex} Found: {app_channel}"
+        ), f"Failed correctness check. Expected: {channel_regex} Found: {app_channel}"
 
     # Check that everything is active/idle
     await ops_test.model.wait_for_idle(

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -191,7 +191,7 @@ async def test_bundle_correctness(ops_test, kubeflow_model, charm_list):
     Tests are specific to each Charmed Kubeflow version release. This test makes sure that
     the correct version of the bundle, consistent with the tests, is specified. In order to
     check the correctness, we use a YAML bundle that is pulled from the correct URL in the
-    bundle-kubeflow repository. This value can be overridden using the `--bundle` argument. 
+    bundle-kubeflow repository. This value can be overridden using the `--bundle` argument.
     """
 
     if not charm_list:


### PR DESCRIPTION
Fix #157

Addressing [KF-6902](https://warthogs.atlassian.net/browse/KF-6902)

[KF-6902]: https://warthogs.atlassian.net/browse/KF-6902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Some changes are required also in the bundle. [This PR](https://github.com/canonical/bundle-kubeflow/pull/1205) covers the modifications there.