### PR TITLE
fix(kserve): Retry getting the ISVC URL

### DIFF
--- a/tests/notebooks/cpu/kserve/kserve-integration.ipynb
+++ b/tests/notebooks/cpu/kserve/kserve-integration.ipynb
@@ -205,9 +205,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "isvc_resp = client.get(ISVC_NAME)\n",
-    "isvc_url = isvc_resp[\"status\"][\"address\"][\"url\"]\n",
-    "print(\"Inference URL:\", isvc_url)"
+    "@retry(\n",
+    "    wait=wait_exponential(multiplier=2, min=1, max=10),\n",
+    "    stop=stop_after_attempt(30),\n",
+    "    reraise=True,\n",
+    ")\n",
+    "def get_isvc_url(client, isvc_name):\n",
+    "    \"\"\"Get ISVC from client and return it's URL\n",
+    "\n",
+    "    Add a retry clause to address the following intermittent issue\n",
+    "    https://github.com/canonical/bundle-kubeflow/issues/1100\"\"\"\n",
+    "    isvc_object = client.get(isvc_name)\n",
+    "    return isvc_object[\"status\"][\"address\"][\"url\"]\n",
+    "\n",
+    "\n",
+    "url = get_isvc_url(client, ISVC_NAME)\n",
+    "print(\"Inference URL:\", url)"
    ]
   },
   {
@@ -227,7 +240,7 @@
    "outputs": [],
    "source": [
     "inference_input = {\"instances\": [[6.8, 2.8, 4.8, 1.4], [6.0, 3.4, 4.5, 1.6]]}\n",
-    "response = requests.post(f\"{isvc_url}/v1/models/sklearn-iris:predict\", json=inference_input)\n",
+    "response = requests.post(f\"{url}/v1/models/sklearn-iris:predict\", json=inference_input)\n",
     "print(response.text)"
    ]
   },


### PR DESCRIPTION
Retry getting the ISVC URL since it failed intermitently why the ISVC had been created.

Fix canonical/bundle-kubeflow#1100

### Testing

In order to run UATs from the branch, we 'd need to first merge #158. You can test this though from a branch that has KServe fix and the #158 fix (or removes the `test_bundle_correctness` check).