### PR TITLE
chore: update reference to 1.10/stable bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ As mentioned before, when it comes to running the tests, you've got 2 options:
 * Running the tests on an existing cluster using the `driver` along with the provided automation
 
 NOTE: Depending on the version of Charmed Kubeflow you want to test, make sure to checkout to the appropriate branch with `git checkout`:
+- Charmed Kubeflow 1.10 -> `track/1.10`
 - Charmed Kubeflow 1.9 -> `track/1.9`
 - Charmed Kubeflow 1.8 -> `track/1.8`
-- Charmed Kubeflow 1.7 -> `track/1.7`
+- Charmed Kubeflow 1.7 -> `track/1.7` (Deprecated)
 
 The `main` branch is generally used for testing against the `latest/edge` track of the bundle.   
 

--- a/driver/conftest.py
+++ b/driver/conftest.py
@@ -3,7 +3,7 @@
 
 from _pytest.config.argparsing import Parser
 
-BUNDLE_URL = "https://raw.githubusercontent.com/canonical/bundle-kubeflow/refs/heads/main/releases/latest/edge/bundle.yaml"
+BUNDLE_URL = "https://raw.githubusercontent.com/canonical/bundle-kubeflow/refs/heads/main/releases/1.10/stable/bundle.yaml"
 
 
 def pytest_addoption(parser: Parser):


### PR DESCRIPTION
Updating the `BUNDLE_URL` reference to point to the 1.10 stable bundle for the 1.10 releases