### PR TITLE
[KF-7085] chore: check active/idle only for bundle charms (#177)

### DIFF
--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -207,9 +207,9 @@ async def test_bundle_correctness(ops_test, kubeflow_model, charm_list):
             app_channel
         ), f"Failed bundle correctness check. Expected: {channel_regex} Found: {app_channel}"
 
-    # Check that everything is active/idle
+    # Check that every charm of the bundle is active/idle
     await ops_test.model.wait_for_idle(
-        apps=list(status["applications"]),
+        apps=list(charm_list),
         timeout=3600,
         idle_period=30,
         status="active",


### PR DESCRIPTION
Forward ports #177 to main

## Summary
In the TF deployment there is one charm that is in blocked status by design, which prevents the UATs to pass. This change only restrict the check for active/idle to the KF charms only.