### PR TITLE
feat: increase timeout in Kubeflow Trainer V2 UATs

### DIFF
--- a/tests/notebooks/kubeflow-trainer/kubeflow-trainer-integration.ipynb
+++ b/tests/notebooks/kubeflow-trainer/kubeflow-trainer-integration.ipynb
@@ -181,7 +181,7 @@
    },
    "outputs": [],
    "source": [
-    "client.wait_for_job_status(name=job_name, status={\"Complete\"})"
+    "client.wait_for_job_status(name=job_name, status={\"Complete\"}, timeout=1200)"
    ]
   },
   {
@@ -427,7 +427,7 @@
    },
    "outputs": [],
    "source": [
-    "client.wait_for_job_status(name=job_name, status={\"Complete\"})"
+    "client.wait_for_job_status(name=job_name, status={\"Complete\"}, timeout=1200)"
    ]
   },
   {


### PR DESCRIPTION
After adding UATs for Kubeflow Trainer V2 with #216, they randomly fail for timeouts (see [this PR](https://github.com/canonical/charmed-kubeflow-solutions/pull/85)) as an example.

This PR increases the timeout to 20 minutes in the tests.