### PR TITLE
(backport): feat: increase timeout in Kubeflow Trainer V2 UATs

### DIFF
--- a/tests/notebooks/kubeflow-trainer/kubeflow-trainer-integration.ipynb
+++ b/tests/notebooks/kubeflow-trainer/kubeflow-trainer-integration.ipynb
@@ -181,7 +181,7 @@
    },
    "outputs": [],
    "source": [
-    "client.wait_for_job_status(name=job_name, status={\"Complete\"})"
+    "client.wait_for_job_status(name=job_name, status={\"Complete\"}, timeout=1200)"
    ]
   },
   {
@@ -427,7 +427,7 @@
    },
    "outputs": [],
    "source": [
-    "client.wait_for_job_status(name=job_name, status={\"Complete\"})"
+    "client.wait_for_job_status(name=job_name, status={\"Complete\"}, timeout=1200)"
    ]
   },
   {


### PR DESCRIPTION
Backports #227 to `track/1.10` to fix flaky tests for Kubeflow Trainer V2 due to slow CI.