### PR TITLE
[KF-8396] Provide simple API to run Kubeflow+MLFlow tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ found in the [Run the tests](#run-the-tests) section.
       * [Specify a different bundle](#specify-a-different-bundle)
       * [Kubeflow UATs](#run-kubeflow-uats)
       * [MLflow UATs](#run-mlflow-uats)
+      * [Kubeflow+MLflow UATs](#run-kubeflow+mlflow-uats)
       * [Feast UATs](#run-feast-uats)
    * [NVIDIA GPU UAT](#nvidia-gpu-uat)
       * [From inside a notebook](#run-nvidia-gpu-uat-from-inside-a-notebook)

--- a/tox.ini
+++ b/tox.ini
@@ -63,14 +63,14 @@ commands =
 [testenv:kubeflow-{local,remote}]
 description = Run UATs for Kubeflow
 commands =
-    # run all tests apart from the ones that use MLFlow
+    # run all tests for Kubeflow only
     poetry install --no-root
     poetry run pytest -vv --tb native {[vars]driver_path} -s --filter "not spark and not mlflow and not feast" --model kubeflow {posargs}
 
 [testenv:kubeflow-mlflow-{local,remote}]
 description = Run UATs for Kubeflow+MLFlow
 commands =
-    # run all tests apart from the ones that use MLFlow
+    # run all tests for Kubeflow+MLFlow
     poetry install --no-root
     poetry run pytest -vv --tb native {[vars]driver_path} -s --filter "not spark and not feast" --model kubeflow {posargs}
 


### PR DESCRIPTION
Having a simple API for running Kubeflow + MLFlow tests is very beneficial for SolQA. Right now they would need to filter by feast and by spark, complicating a scalable setup for SolQA tests