### PR TITLE
fix(cherry-pick): add label to disable istio in training UATs (#241)

### DIFF
--- a/tests/notebooks/cpu/training/training-integration.ipynb
+++ b/tests/notebooks/cpu/training/training-integration.ipynb
@@ -152,9 +152,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "training_labels = {}\n",
+    "training_labels = {\"istio.io/dataplane-mode\": \"none\"}\n",
     "if os.environ.get(\"HTTP_PROXY\") and os.environ.get(\"HTTPS_PROXY\") and os.environ.get(\"NO_PROXY\"):\n",
-    "    training_labels = {\"notebook-proxy\": \"true\"}"
+    "    training_labels[\"notebook-proxy\"] = \"true\""
    ]
   },
   {
@@ -715,7 +715,9 @@
     "    replicas=2,\n",
     "    restart_policy=\"OnFailure\",\n",
     "    template=V1PodTemplateSpec(\n",
-    "        metadata=V1ObjectMeta(annotations={\"sidecar.istio.io/inject\": \"false\"}),\n",
+    "        metadata=V1ObjectMeta(\n",
+    "            annotations={\"sidecar.istio.io/inject\": \"false\"}, labels=training_labels\n",
+    "        ),\n",
     "        spec=V1PodSpec(containers=[container]),\n",
     "    ),\n",
     ")\n",


### PR DESCRIPTION
Forward-ports #241 to `main`