### PR TITLE
Add sqa_tests for SQA's Terragrunt Pipelines

### DIFF
--- a/sqa_tests
+++ b/sqa_tests
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -xou pipefail
+
+MODEL=kubeflow
+TEST_OPTION=kubeflow-remote
+
+OUTPUT_RESULTS=$PWD/test_results.xml
+OUTPUT_METRICS=metrics.json
+
+sudo add-apt-repository ppa:deadsnakes/ppa -y
+sudo apt update -y
+sudo apt install python3.12 python3.12-venv -y
+
+python3.12 -m venv venv
+source venv/bin/activate
+
+HTTPS_PROXY=http://squid.internal:3128 pip install --upgrade tox
+
+juju status --model "${MODEL}" --utc
+
+# poetry does not respect /etc/pip.conf to use proxy for contacting PyPI
+HTTPS_PROXY=http://squid.internal:3128 tox -e "${TEST_OPTION}" -- --no-test ||
+    echo "Ignore the Error, only downloaded packages"
+
+TERM=dumb timeout 4h tox -e ${TEST_OPTION} -- \
+    --junit-xml="$OUTPUT_RESULTS" \
+    "$@"  # passed 'args'
+
+# (placeholder) A file containing metrics from the test run.
+#   Currently only expected, but not used.  Empty is okay.
+touch $OUTPUT_METRICS


### PR DESCRIPTION
This script adds a minimal `sqa_tests` script ([SQ088](https://docs.google.com/document/d/1ElnTb2nvt4h_l-Rtxbcwj8P0Tax7CL_PEDZVFzEOEoI/edit?usp=sharing)) that enables running these UATs to test Kubeflow deployments from SQA's Terragrunt Pipelines.

This script can help serve as a reference for you to implement something better, but "should work" as is.

Following key points to keep in mind:

- We currently only deploy the `kubeflow` module, and currently only from the default branch of [charmed-kubeflow-solutions](https://github.com/canonical/charmed-kubeflow-solutions).  I believe then the appropriate UATs' branch is `track/1.10`, this PR's target.
- The test runner managing the deployment is always behind proxy, the handling for which is hard-coded in the script.
- Per SQ088, the results are collected in a JUnit XML `test_results.xml`.  A stub `metrics.json` is also created for future usage.
- Once this is script is available in the `track/1.10` branch of this repo, the parameters json to use when triggering tests would look like this (with your own custom args):
  ```json
  {"repo":"canonical/charmed-kubeflow-uats","ref":"track/1.10","subdir":".","args":["--include-gpu-tests", "-k", "not security"]}
  ```