### PR TITLE
[KF-8632] Ambient enablement on 1.11 release

### DIFF
--- a/assets/versions-ambient.yaml
+++ b/assets/versions-ambient.yaml
@@ -1,71 +1,71 @@
 applications:
   admission-webhook:
-    channel: latest/
+    channel: 2.0/
   argo-controller:
-    channel: latest/
+    channel: 3.7/
   dex-auth:
-    channel: latest/
+    channel: 2.41/
   envoy:
-    channel: latest/
-  istio-k8s:
+    channel: 2.4/
+  istio-beacon-k8s:
     channel: 2/
   istio-ingress-k8s:
     channel: 2/
-  istio-beacon-k8s:
+  istio-k8s:
     channel: 2/
   jupyter-controller:
-    channel: latest/
+    channel: 1.11/
   jupyter-ui:
-    channel: latest/
+    channel: 1.11/
   katib-controller:
-    channel: latest/
+    channel: 0.19/
   katib-db:
     channel: 8.0/
   katib-db-manager:
-    channel: latest/
+    channel: 0.19/
   katib-ui:
-    channel: latest/
+    channel: 0.19/
   kfp-api:
-    channel: latest/
+    channel: 2.15/
   kfp-db:
     channel: 8.0/
   kfp-metadata-writer:
-    channel: latest/
+    channel: 2.15/
   kfp-persistence:
-    channel: latest/
+    channel: 2.15/
   kfp-profile-controller:
-    channel: latest/
+    channel: 2.15/
   kfp-schedwf:
-    channel: latest/
+    channel: 2.15/
   kfp-ui:
-    channel: latest/
+    channel: 2.15/
   kfp-viewer:
-    channel: latest/
+    channel: 2.15/
   kfp-viz:
-    channel: latest/
+    channel: 2.15/
   kserve-controller:
-    channel: latest/
+    channel: 0.15/
   kubeflow-dashboard:
-    channel: latest/
+    channel: 2.0/
   kubeflow-profiles:
-    channel: latest/
+    channel: 2.0/
   kubeflow-roles:
-    channel: latest/
+    channel: 1.10/
   kubeflow-volumes:
-    channel: latest/
+    channel: 1.11/
   metacontroller-operator:
-    channel: latest/
+    channel: 4.11/
   minio:
-    channel: latest/
+    channel: 1.10/
   mlmd:
-    channel: latest/
+    channel: ckf-1.10/
   oidc-gatekeeper:
-    channel: latest/
+    channel: ckf-1.10/
   pvcviewer-operator:
-    channel: latest/
+    channel: 1.11/
   tensorboard-controller:
-    channel: latest/
+    channel: 1.11/
   tensorboards-web-app:
-    channel: latest/
+    channel: 1.11/
   training-operator:
-    channel: latest/
+    channel: 1.9/

--- a/assets/versions-ambient.yaml
+++ b/assets/versions-ambient.yaml
@@ -26,23 +26,23 @@ applications:
   katib-ui:
     channel: 0.19/
   kfp-api:
-    channel: 2.15/
+    channel: 2.16/
   kfp-db:
     channel: 8.0/
   kfp-metadata-writer:
-    channel: 2.15/
+    channel: 2.16/
   kfp-persistence:
-    channel: 2.15/
+    channel: 2.16/
   kfp-profile-controller:
-    channel: 2.15/
+    channel: 2.16/
   kfp-schedwf:
-    channel: 2.15/
+    channel: 2.16/
   kfp-ui:
-    channel: 2.15/
+    channel: 2.16/
   kfp-viewer:
-    channel: 2.15/
+    channel: 2.16/
   kfp-viz:
-    channel: 2.15/
+    channel: 2.16/
   kserve-controller:
     channel: 0.15/
   kubeflow-dashboard:

--- a/assets/versions-sidecar.yaml
+++ b/assets/versions-sidecar.yaml
@@ -1,6 +1,6 @@
 applications:
   admission-webhook:
-    channel: 1.10/
+    channel: 2.0/
   argo-controller:
     channel: 3.7/
   dex-auth:
@@ -12,9 +12,9 @@ applications:
   istio-pilot:
     channel: 1.28/
   jupyter-controller:
-    channel: 1.10/
+    channel: 1.11/
   jupyter-ui:
-    channel: 1.10/
+    channel: 1.11/
   katib-controller:
     channel: 0.19/
   katib-db:
@@ -50,13 +50,13 @@ applications:
   kserve-controller:
     channel: 0.15/
   kubeflow-dashboard:
-    channel: 1.10/
+    channel: 2.0/
   kubeflow-profiles:
     channel: 1.10/
   kubeflow-roles:
     channel: 1.10/
   kubeflow-volumes:
-    channel: 1.10/
+    channel: 1.11/
   metacontroller-operator:
     channel: 4.11/
   minio:
@@ -66,10 +66,10 @@ applications:
   oidc-gatekeeper:
     channel: ckf-1.10/
   pvcviewer-operator:
-    channel: 1.10/
+    channel: 1.11/
   tensorboard-controller:
-    channel: 1.10/
+    channel: 1.11/
   tensorboards-web-app:
-    channel: 1.10/
+    channel: 1.11/
   training-operator:
     channel: 1.9/

--- a/assets/versions-sidecar.yaml
+++ b/assets/versions-sidecar.yaml
@@ -52,7 +52,7 @@ applications:
   kubeflow-dashboard:
     channel: 2.0/
   kubeflow-profiles:
-    channel: 1.10/
+    channel: 2.0/
   kubeflow-roles:
     channel: 1.10/
   kubeflow-volumes:

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -234,7 +234,6 @@ def create_poddefault_on_security_policy(request, lightkube_client):
 
 @pytest.mark.dependency()
 @pytest.mark.abort_on_fail
-@pytest.mark.dependency()
 async def test_bundle_correctness(ops_test, kubeflow_model, charm_list):
     """Test that the correct bundle is selected.
 

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -232,6 +232,7 @@ def create_poddefault_on_security_policy(request, lightkube_client):
         )
 
 
+@pytest.mark.dependency()
 @pytest.mark.abort_on_fail
 @pytest.mark.dependency()
 async def test_bundle_correctness(ops_test, kubeflow_model, charm_list):

--- a/tests/notebooks/cpu/training/training-integration.ipynb
+++ b/tests/notebooks/cpu/training/training-integration.ipynb
@@ -184,7 +184,7 @@
    "outputs": [],
    "source": [
     "training_labels = {\"istio.io/dataplane-mode\": \"none\"}\n",
-    "if os.environ.get(\"HTTP_PROXY\") and os.environ.get(\"HTTPS_PROXY\") and os.environ.get(\"NO_PROXY\"):\n",
+    "if PROXY_ENVS_SET:\n",
     "    training_labels[\"notebook-proxy\"] = \"true\""
    ]
   },
@@ -747,7 +747,8 @@
     "    restart_policy=\"OnFailure\",\n",
     "    template=V1PodTemplateSpec(\n",
     "        metadata=V1ObjectMeta(\n",
-    "            annotations={\"sidecar.istio.io/inject\": \"false\"}, labels=training_labels\n",
+    "            annotations={\"sidecar.istio.io/inject\": \"false\"},\n",
+    "            labels={\"istio.io/dataplane-mode\": \"none\"},\n",
     "        ),\n",
     "        spec=V1PodSpec(containers=[container]),\n",
     "    ),\n",


### PR DESCRIPTION
companion PR of https://github.com/canonical/charmed-kubeflow-solutions/pull/179

Beside backporting a few changes (ambient tests), this PR also propose some small quality improvements that I have highlighted in the comments below.

I have raised a similar PR in main (https://github.com/canonical/charmed-kubeflow-uats/pull/265) reflecting those comments and changes. 

I wold probably wait for the PR on main to land, and then update the current PR with the reference, such that it will resemble a backport