### PR TITLE
feat: Update kfp dependency to 2.16

### DIFF
--- a/tests/notebooks/cpu/kfp_v2/requirements.in
+++ b/tests/notebooks/cpu/kfp_v2/requirements.in
@@ -1,3 +1,3 @@
 # pin the highest kfp version
-kfp>=2.15,<3.0
+kfp>=2.16,<3.0
 tenacity

--- a/tests/notebooks/cpu/kfp_v2/requirements.txt
+++ b/tests/notebooks/cpu/kfp_v2/requirements.txt
@@ -49,11 +49,11 @@ googleapis-common-protos==1.72.0
     # via google-api-core
 idna==3.11
     # via requests
-kfp==2.15.2
+kfp==2.16.1
     # via -r requirements.in
-kfp-pipeline-spec==2.15.2
+kfp-pipeline-spec==2.16.1
     # via kfp
-kfp-server-api==2.15.2
+kfp-server-api==2.16.1
     # via kfp
 kubernetes==30.1.0
     # via kfp

--- a/tests/notebooks/cpu/spark-pipeline/requirements.in
+++ b/tests/notebooks/cpu/spark-pipeline/requirements.in
@@ -1,3 +1,3 @@
 # pin the highest kfp version
-kfp[kubernetes]>=2.15,<3.0
+kfp[kubernetes]>=2.16,<3.0
 tenacity

--- a/tests/notebooks/cpu/spark-pipeline/requirements.txt
+++ b/tests/notebooks/cpu/spark-pipeline/requirements.txt
@@ -49,15 +49,15 @@ googleapis-common-protos==1.72.0
     # via google-api-core
 idna==3.11
     # via requests
-kfp[kubernetes]==2.15.2
+kfp[kubernetes]==2.16.1
     # via
     #   -r requirements.in
     #   kfp-kubernetes
-kfp-kubernetes==2.15.2
+kfp-kubernetes==2.16.1
     # via kfp
-kfp-pipeline-spec==2.15.2
+kfp-pipeline-spec==2.16.1
     # via kfp
-kfp-server-api==2.15.2
+kfp-server-api==2.16.1
     # via kfp
 kubernetes==30.1.0
     # via kfp


### PR DESCRIPTION
## Summary
This PR updates the `requirements.in` in the `kfp_v2` and `spark-pipeline` tests to use `2.16` version of the `kfp` SDK.

Closes https://github.com/canonical/kfp-operators/issues/877

## Notes
- We cannot update the `kfp` version in the `e2ewine` test, since there is a `protobuff` conflict with the version of `kserve` that we want:
```
pip-compile ERROR: Cannot install -r requirements.in (line 13), -r requirements.in (line 3) and mlflow because these package versions have conflicting dependencies. Traceback (most recent call last): File "/home/ubuntu/can/charmed-kubeflow-uats/tests/notebooks/cpu/kfp_v2/venv/lib/python3.11/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 95, in resolve result = self._result = resolver.resolve( ^^^^^^^^^^^^^^^^^ File "/home/ubuntu/can/charmed-kubeflow-uats/tests/notebooks/cpu/kfp_v2/venv/lib/python3.11/site-packages/pip/_vendor/resolvelib/resolvers.py", line 546, in resolve state = resolution.resolve(requirements, max_rounds=max_rounds) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/ubuntu/can/charmed-kubeflow-uats/tests/notebooks/cpu/kfp_v2/venv/lib/python3.11/site-packages/pip/_vendor/resolvelib/resolvers.py", line 439, in resolve raise ResolutionImpossible(self.state.backtrack_causes) pip._vendor.resolvelib.resolvers.ResolutionImpossible: [RequirementInformation(requirement=SpecifierRequirement('protobuf<5.0.0,>=4.25.4'), parent=LinkCandidate('https://files.pythonhosted.org/packages/31/15/d167cd6dd09a2d70e7741700ffa1228c94be8bdaa59b5a88b3b2259e5f40/kserve-0.15.2-py3-none-any.whl (from https://pypi.org/simple/kserve/) (requires-python:<3.13,>=3.9)')), RequirementInformation(requirement=SpecifierRequirement('protobuf<7,>=3.12.0'), parent=LinkCandidate('https://files.pythonhosted.org/packages/f9/d1/549a995e261ca708c60fe0b63dfa4d1842fc58b04eb9c78cd678aebe1e7e/mlflow_skinny-2.22.4-py3-none-any.whl (from https://pypi.org/simple/mlflow-skinny/) (requires-python:>=3.9)')), RequirementInformation(requirement=SpecifierRequirement('protobuf<7.0,>=6.31.1'), parent=LinkCandidate('https://files.pythonhosted.org/packages/b7/64/c2393ab7410017cefd5fd5693811a77d7d55d5b02faf09a9e6402c4d187c/kfp-2.16.1-py3-none-any.whl (from https://pypi.org/simple/kfp/) (requires-python:>=3.9.0)')), RequirementInformation(requirement=SpecifierRequirement('protobuf<5.0.0,>=4.25.4'), parent=LinkCandidate('https://files.pythonhosted.org/packages/31/15/d167cd6dd09a2d70e7741700ffa1228c94be8bdaa59b5a88b3b2259e5f40/kserve-0.15.2-py3-none-any.whl (from https://pypi.org/simple/kserve/) (requires-python:<3.13,>=3.9)')), RequirementInformation(requirement=SpecifierRequirement('protobuf<7,>=3.12.0'), parent=LinkCandidate('https://files.pythonhosted.org/packages/f9/d1/549a995e261ca708c60fe0b63dfa4d1842fc58b04eb9c78cd678aebe1e7e/mlflow_skinny-2.22.4-py3-none-any.whl (from https://pypi.org/simple/mlflow-skinny/) (requires-python:>=3.9)')), RequirementInformation(requirement=SpecifierRequirement('protobuf<7.0,>=6.31.1'), parent=LinkCandidate('https://files.pythonhosted.org/packages/84/71/8cc07a616412cc78b57481bf49248c74584881078c22c16d6c465a73f528/kfp-2.16.0-py3-none-any.whl (from https://pypi.org/simple/kfp/) (requires-python:>=3.9.0)'))]
```