### PR TITLE
feat: allow UATs on any namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,12 @@ tox -e uats-local -- --kubeflow-model kf-system
 ```
 
 This flag controls both the juju model name used for bundle checks and the Kubernetes namespace
-where the KFP API endpoint (`ml-pipeline` service) is located. The namespace is used to construct
-the `KF_PIPELINES_ENDPOINT` environment variable, which the KFP SDK reads to connect to the correct
-API server.
+where the KFP API endpoint (`ml-pipeline` service) is located. The driver injects two environment
+variables into the test Job container:
+- `KUBEFLOW_NAMESPACE` — the namespace where the Kubeflow control plane is deployed (used by
+  `kfp.Client(namespace=...)` to connect to the correct API server)
+- `USER_NAMESPACE` — the profile namespace where pipeline runs are submitted (used by
+  `client.set_user_namespace(...)` to target the correct user profile)
 
 #### Run Kubeflow UATs
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,22 @@ The `<my-bundle>` can be replaced by either a URL, e.g. `http://...`, or a local
 
 This flag is currently only provided on main branch and tracks 1.9+. 
 
+#### Specify the Kubeflow control-plane namespace
+
+By default, the UATs assume the Kubeflow control plane (including the `ml-pipeline` API service)
+is deployed in the `kubeflow` namespace. If your Charmed Kubeflow installation is deployed to a
+different namespace, use the `--kubeflow-model` flag to specify the namespace where Kubeflow is deployed:
+
+```bash
+# run tests against Kubeflow deployed to the kf-system namespace
+tox -e uats-local -- --kubeflow-model kf-system
+```
+
+This flag controls both the juju model name used for bundle checks and the Kubernetes namespace
+where the KFP API endpoint (`ml-pipeline` service) is located. The namespace is used to construct
+the `KF_PIPELINES_ENDPOINT` environment variable, which the KFP SDK reads to connect to the correct
+API server.
+
 #### Run Kubeflow UATs
 
 In order to only run the Kubeflow-specific tests (i.e. no MLflow integration) you can use the

--- a/README.md
+++ b/README.md
@@ -211,11 +211,11 @@ This flag is currently only provided on main branch and tracks 1.9+.
 
 By default, the UATs assume the Kubeflow control plane (including the `ml-pipeline` API service)
 is deployed in the `kubeflow` namespace. If your Charmed Kubeflow installation is deployed to a
-different namespace, use the `--kubeflow-model` flag to specify the namespace where Kubeflow is deployed:
+different namespace, use the `--model` flag to specify the namespace where Kubeflow is deployed:
 
 ```bash
 # run tests against Kubeflow deployed to the kf-system namespace
-tox -e uats-local -- --kubeflow-model kf-system
+tox -e uats-local -- --model kf-system
 ```
 
 This flag controls both the juju model name used for bundle checks and the Kubernetes namespace

--- a/assets/test-job.yaml.j2
+++ b/assets/test-job.yaml.j2
@@ -53,8 +53,10 @@ spec:
               python3 -m pip install -r requirements.txt >/dev/null;
               {{ pytest_cmd }}
           env:
-            - name: KF_PIPELINES_ENDPOINT
-              value: "http://ml-pipeline.{{ kubeflow_namespace }}.svc.cluster.local:8888"
+            - name: KUBEFLOW_NAMESPACE
+              value: {{ kubeflow_namespace }}
+            - name: USER_NAMESPACE
+              value: {{ user_namespace }}
           volumeMounts:
             - name: test-volume
               mountPath: /tests

--- a/assets/test-job.yaml.j2
+++ b/assets/test-job.yaml.j2
@@ -52,6 +52,9 @@ spec:
               {% endif %}
               python3 -m pip install -r requirements.txt >/dev/null;
               {{ pytest_cmd }}
+          env:
+            - name: KF_PIPELINES_ENDPOINT
+              value: "http://ml-pipeline.{{ kubeflow_namespace }}.svc.cluster.local:8888"
           volumeMounts:
             - name: test-volume
               mountPath: /tests

--- a/driver/ambient/test_ambient_integration.py
+++ b/driver/ambient/test_ambient_integration.py
@@ -126,7 +126,7 @@ def create_curl_pod(lightkube_client, create_profile_2):
     depends=["driver/test_kubeflow_workloads.py::test_bundle_correctness"], scope="session"
 )
 def test_ambient_rbac_isolation(
-    lightkube_client, create_profile_1, create_profile_2, create_curl_pod
+    lightkube_client, create_profile_1, create_profile_2, create_curl_pod, kubeflow_model
 ):
     """Test that ambient mesh prevents cross-profile access via RBAC.
 
@@ -146,7 +146,7 @@ def test_ambient_rbac_isolation(
         "\\nHTTP_CODE:%{http_code}",
         "-H",
         f"kubeflow-userid: {NAMESPACE_1}@email.com",
-        f"ml-pipeline.kubeflow.svc:8888/apis/v2beta1/experiments?namespace={NAMESPACE_1}",
+        f"ml-pipeline.{kubeflow_model}.svc:8888/apis/v2beta1/experiments?namespace={NAMESPACE_1}",
     ]
 
     stdout, stderr, returncode = exec_in_pod(pod_name, NAMESPACE_2, curl_command)

--- a/driver/conftest.py
+++ b/driver/conftest.py
@@ -94,7 +94,8 @@ def pytest_addoption(parser: Parser):
     parser.addoption(
         "--kubeflow-model",
         default="kubeflow",
-        help="Provide the name of the namespace/juju model where kubeflow is deployed.",
+        help="Provide the name of the namespace/juju model where kubeflow is deployed. "
+        "This is used to determine the Kubeflow control-plane namespace for the KFP API endpoint.",
     )
     parser.addoption(
         "--bundle",

--- a/driver/conftest.py
+++ b/driver/conftest.py
@@ -93,7 +93,6 @@ def pytest_addoption(parser: Parser):
     )
     parser.addoption(
         "--kubeflow-model",
-        default="kubeflow",
         help="Provide the name of the namespace/juju model where kubeflow is deployed. "
         "This is used to determine the Kubeflow control-plane namespace for the KFP API endpoint.",
     )

--- a/driver/conftest.py
+++ b/driver/conftest.py
@@ -26,7 +26,6 @@ def pytest_addoption(parser: Parser):
       of your Kubernetes cluster. The default one for MicroK8s is otherwise assumed.
     * Add a `--security-policy` option to specify the security policy (privileged or baseline)
       defined in `kubeflow-profiles` for the testing namespace.
-    * Add a `--kubeflow-model` option to specify the juju model where kubeflow is deployed.
     * Add a `--test-image` option to specify the test image to be used by the driver notebook pod.
     * Add an `--include-ambient-tests` flag to include the ambient integration tests in the
       executed tests.
@@ -90,11 +89,6 @@ def pytest_addoption(parser: Parser):
         " For more information, see: \n"
         " https://kubernetes.io/docs/concepts/security/pod-security-standards/",
         action="store",
-    )
-    parser.addoption(
-        "--kubeflow-model",
-        help="Provide the name of the namespace/juju model where kubeflow is deployed. "
-        "This is used to determine the Kubeflow control-plane namespace for the KFP API endpoint.",
     )
     parser.addoption(
         "--bundle",

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -134,13 +134,6 @@ def include_kubeflow_trainer_tests(request):
 
 
 @pytest.fixture(scope="module")
-def kubeflow_model(request, ops_test):
-    """Retrieve name of the model where Kubeflow is deployed."""
-    model_name = request.config.getoption("--kubeflow-model")
-    return model_name if model_name else ops_test.model.name
-
-
-@pytest.fixture(scope="module")
 def tests_checked_out_commit(request):
     """Retrieve active git commit."""
     head = subprocess.check_output(["git", "rev-parse", "HEAD"])
@@ -234,7 +227,7 @@ def create_poddefault_on_security_policy(request, lightkube_client):
 
 @pytest.mark.abort_on_fail
 @pytest.mark.dependency()
-async def test_bundle_correctness(ops_test, kubeflow_model, charm_list):
+async def test_bundle_correctness(ops_test, charm_list):
     """Test that the correct bundle is selected.
 
     Tests are specific to each Charmed Kubeflow version release. This test makes sure that
@@ -246,8 +239,7 @@ async def test_bundle_correctness(ops_test, kubeflow_model, charm_list):
     if not charm_list:
         pytest.skip("charm_list empty. Cannot test bundle correctness")
 
-    model = await ops_test.track_model("kubeflow", model_name=kubeflow_model, use_existing=True)
-    status = await model.get_status()
+    status = await ops_test.model.get_status()
 
     # Check that the version is the one expected by this set of tests
     for name, channel_regex in charm_list.items():
@@ -257,7 +249,7 @@ async def test_bundle_correctness(ops_test, kubeflow_model, charm_list):
         ), f"Failed bundle correctness check for charm {name}. Expected: {channel_regex} Found: {app_channel}"
 
     # Check that every charm of the bundle is active/idle
-    await model.wait_for_idle(
+    await ops_test.model.wait_for_idle(
         apps=list(charm_list),
         timeout=3600,
         idle_period=30,
@@ -308,8 +300,8 @@ async def test_create_profile(lightkube_client, create_profile):
 
 @pytest.mark.dependency(depends=["test_create_profile"])
 def test_kubeflow_workloads(
+    ops_test,
     k8s_default_runtimeclass_handler,
-    kubeflow_model,
     lightkube_client,
     pytest_cmd,
     tests_checked_out_commit,
@@ -347,7 +339,7 @@ def test_kubeflow_workloads(
                 "pytest_cmd": pytest_cmd,
                 "proxy": True if request.config.getoption("proxy") else False,
                 "security_policy": request.config.getoption("security_policy") != "privileged",
-                "kubeflow_namespace": kubeflow_model,
+                "kubeflow_namespace": ops_test.model.name,
                 "user_namespace": NAMESPACE,
             },
         )

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -346,6 +346,7 @@ def test_kubeflow_workloads(
                 "pytest_cmd": pytest_cmd,
                 "proxy": True if request.config.getoption("proxy") else False,
                 "security_policy": request.config.getoption("security_policy") != "privileged",
+                "kubeflow_namespace": kubeflow_model,
             },
         )
     )

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -309,6 +309,7 @@ async def test_create_profile(lightkube_client, create_profile):
 @pytest.mark.dependency(depends=["test_create_profile"])
 def test_kubeflow_workloads(
     k8s_default_runtimeclass_handler,
+    kubeflow_model,
     lightkube_client,
     pytest_cmd,
     tests_checked_out_commit,

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -257,7 +257,7 @@ async def test_bundle_correctness(ops_test, kubeflow_model, charm_list):
         ), f"Failed bundle correctness check for charm {name}. Expected: {channel_regex} Found: {app_channel}"
 
     # Check that every charm of the bundle is active/idle
-    await ops_test.model.wait_for_idle(
+    await model.wait_for_idle(
         apps=list(charm_list),
         timeout=3600,
         idle_period=30,

--- a/driver/test_kubeflow_workloads.py
+++ b/driver/test_kubeflow_workloads.py
@@ -348,6 +348,7 @@ def test_kubeflow_workloads(
                 "proxy": True if request.config.getoption("proxy") else False,
                 "security_policy": request.config.getoption("security_policy") != "privileged",
                 "kubeflow_namespace": kubeflow_model,
+                "user_namespace": NAMESPACE,
             },
         )
     )

--- a/tests/notebooks/cpu/kfp_v2/kfp-v2-integration.ipynb
+++ b/tests/notebooks/cpu/kfp_v2/kfp-v2-integration.ipynb
@@ -54,7 +54,10 @@
    },
    "outputs": [],
    "source": [
-    "client = kfp.Client()"
+    "kubeflow_namespace = os.environ.get(\"KUBEFLOW_NAMESPACE\", \"kubeflow\")\n",
+    "user_namespace = os.environ.get(\"USER_NAMESPACE\", \"test-kubeflow\")\n",
+    "client = kfp.Client(namespace=kubeflow_namespace)\n",
+    "client.set_user_namespace(namespace=user_namespace)"
    ]
   },
   {


### PR DESCRIPTION
This PR adds two environment variables, `KUBEFLOW_NAMESPACE` and `USER_NAMESPACE`, in the notebooks pod and updates Pipelines Client initialization to set properly the control plane and user namespaces.

This PR also removes `--kubeflow-model` configuration option, as it was never used. By default, `tox` environment sets `--model kubeflow`, but it can be changed by the user.

The approach follows the official [Multi-user isolation guide](https://www.kubeflow.org/docs/components/pipelines/operator-guides/multi-user/).

This PR closes #269.

## Testing with Istio ambient mode
This PR has been manually tested against the following environment:

<details>
<summary>Kubeflow deployment - ambient mode</summary>

```
Model             Controller    Cloud/Region  Version  SLA          Timestamp
testing-kubeflow  kf-localhost  kf/localhost  3.6.21   unsupported  09:00:28+02:00

App                      Version  Status  Scale  Charm                    Channel              Rev  Address         Exposed  Message
admission-webhook                 active      1  admission-webhook        latest/edge          615  10.152.183.54   no       
argo-controller                   active      1  argo-controller          latest/edge          905  10.152.183.76   no       
dex-auth                          active      1  dex-auth                 latest/edge          811  10.152.183.75   no       
envoy                             active      1  envoy                    latest/edge          549  10.152.183.18   no       
istio-beacon-k8s                  active      1  istio-beacon-k8s         2/stable              63  10.152.183.244  no       
istio-ingress-k8s                 active      1  istio-ingress-k8s        2/stable              61  10.152.183.41   no       Serving at 10.64.140.43
istio-k8s                1.26.1   active      1  istio-k8s                2/stable              45  10.152.183.205  no       
jupyter-controller                active      1  jupyter-controller       latest/edge         1515  10.152.183.37   no       
jupyter-ui                        active      1  jupyter-ui               latest/edge         1438  10.152.183.100  no       
katib-controller                  active      1  katib-controller         latest/edge/pr-387  1329  10.152.183.66   no       
katib-db-manager                  active      1  katib-db-manager         latest/edge         1273  10.152.183.151  no       
katib-ui                          active      1  katib-ui                 latest/edge         1275  10.152.183.149  no       
kfp-api                           active      1  kfp-api                  latest/edge/pr-899  2640  10.152.183.228  no       
kfp-metadata-writer               active      1  kfp-metadata-writer      latest/edge         1699  10.152.183.135  no       
kfp-persistence                   active      1  kfp-persistence          latest/edge         2642  10.152.183.42   no       
kfp-profile-controller            active      1  kfp-profile-controller   latest/edge/pr-901  2620  10.152.183.197  no       
kfp-schedwf                       active      1  kfp-schedwf              latest/edge         2649  10.152.183.46   no       
kfp-ui                            active      1  kfp-ui                   latest/edge         2649  10.152.183.198  no       
kfp-viewer                        active      1  kfp-viewer               latest/edge/pr-900  2682  10.152.183.21   no       
kfp-viz                           active      1  kfp-viz                  latest/edge         2589  10.152.183.119  no       
kserve-controller                 active      1  kserve-controller        latest/edge         1183  10.152.183.53   no       
kubeflow-dashboard                active      1  kubeflow-dashboard       latest/edge          960  10.152.183.133  no       
kubeflow-profiles                 active      1  kubeflow-profiles        latest/edge          859  10.152.183.195  no       
kubeflow-roles                    active      1  kubeflow-roles           latest/edge          407  10.152.183.147  no       
kubeflow-volumes                  active      1  kubeflow-volumes         latest/edge          604  10.152.183.169  no       
metacontroller-operator           active      1  metacontroller-operator  latest/edge          577  10.152.183.155  no       
minio                             active      1  minio                    latest/edge          659  10.152.183.248  no       
mlmd                              active      1  mlmd                     latest/edge          431  10.152.183.59   no       
mysql-db                 8.0.44   active      1  mysql-k8s                8.0/stable           400  10.152.183.143  no       
oidc-gatekeeper                   active      1  oidc-gatekeeper          latest/edge          622  10.152.183.45   no       
pvcviewer-operator                active      1  pvcviewer-operator       latest/edge          461  10.152.183.146  no       
tensorboard-controller            active      1  tensorboard-controller   latest/edge          690  10.152.183.40   no       
tensorboards-web-app              active      1  tensorboards-web-app     latest/edge          676  10.152.183.48   no       
training-operator                 active      1  training-operator        latest/edge          713  10.152.183.184  no
```

</details>

## Testing with Istio sidecar mode
This PR has been manually tested against the following environment:

<details>
<summary>Kubeflow deployment - sidecar mode</summary>

```
Model             Controller    Cloud/Region  Version  SLA          Timestamp
testing-kubeflow  kf-localhost  kf/localhost  3.6.21   unsupported  09:35:36+02:00

App                      Version  Status  Scale  Charm                    Channel              Rev  Address         Exposed  Message
admission-webhook                 active      1  admission-webhook        latest/edge          615  10.152.183.53   no       
argo-controller                   active      1  argo-controller          latest/edge          905  10.152.183.147  no       
dex-auth                          active      1  dex-auth                 latest/edge          811  10.152.183.85   no       
envoy                             active      1  envoy                    latest/edge          549  10.152.183.227  no       
istio-ingressgateway              active      1  istio-gateway            latest/edge         1606  10.152.183.145  no       
istio-pilot                       active      1  istio-pilot              latest/edge         1544  10.152.183.62   no       
jupyter-controller                active      1  jupyter-controller       latest/edge         1515  10.152.183.89   no       
jupyter-ui                        active      1  jupyter-ui               latest/edge         1438  10.152.183.146  no       
katib-controller                  active      1  katib-controller         latest/edge/pr-387  1329  10.152.183.140  no       
katib-db-manager                  active      1  katib-db-manager         latest/edge         1273  10.152.183.239  no       
katib-ui                          active      1  katib-ui                 latest/edge         1275  10.152.183.93   no       
kfp-api                           active      1  kfp-api                  latest/edge/pr-899  2640  10.152.183.213  no       
kfp-metadata-writer               active      1  kfp-metadata-writer      latest/edge         1699  10.152.183.151  no       
kfp-persistence                   active      1  kfp-persistence          latest/edge         2642  10.152.183.165  no       
kfp-profile-controller            active      1  kfp-profile-controller   latest/edge/pr-901  2620  10.152.183.50   no       
kfp-schedwf                       active      1  kfp-schedwf              latest/edge         2649  10.152.183.180  no       
kfp-ui                            active      1  kfp-ui                   latest/edge         2649  10.152.183.215  no       
kfp-viewer                        active      1  kfp-viewer               latest/edge/pr-900  2682  10.152.183.181  no       
kfp-viz                           active      1  kfp-viz                  latest/edge         2589  10.152.183.19   no       
knative-eventing                  active      1  knative-eventing         latest/edge          967  10.152.183.194  no       
knative-operator                  active      1  knative-operator         latest/edge          929  10.152.183.234  no       
knative-serving                   active      1  knative-serving          latest/edge          966  10.152.183.132  no       
kserve-controller                 active      1  kserve-controller        latest/edge         1183  10.152.183.159  no       
kubeflow-dashboard                active      1  kubeflow-dashboard       latest/edge          960  10.152.183.81   no       
kubeflow-profiles                 active      1  kubeflow-profiles        latest/edge          859  10.152.183.212  no       
kubeflow-roles                    active      1  kubeflow-roles           latest/edge          407  10.152.183.126  no       
kubeflow-volumes                  active      1  kubeflow-volumes         latest/edge          604  10.152.183.133  no       
metacontroller-operator           active      1  metacontroller-operator  latest/edge          577  10.152.183.150  no       
minio                             active      1  minio                    latest/edge          659  10.152.183.183  no       
mlmd                              active      1  mlmd                     latest/edge          431  10.152.183.54   no       
mysql-db                 8.0.44   active      1  mysql-k8s                8.0/stable           400  10.152.183.52   no       
oidc-gatekeeper                   active      1  oidc-gatekeeper          latest/edge          622  10.152.183.17   no       
pvcviewer-operator                active      1  pvcviewer-operator       latest/edge          461  10.152.183.43   no       
tensorboard-controller            active      1  tensorboard-controller   latest/edge          690  10.152.183.246  no       
tensorboards-web-app              active      1  tensorboards-web-app     latest/edge          676  10.152.183.163  no       
training-operator                 active      1  training-operator        latest/edge          713  10.152.183.120  no       
```

</details>